### PR TITLE
feat: upgrade abstract adapter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "nomicfoundation.hardhat-solidity",
+    "JuanBlanco.solidity",
     "dbaeumer.vscode-eslint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[solidity]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "JuanBlanco.solidity"
   },
 
   "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -11,15 +11,8 @@
   "editor.tabSize": 2,
   "eslint.validate": ["javascript", "typescript"],
   "files.eol": "\n",
-  "solidity.formatter": "forge",
   "solidity.packageDefaultDependenciesContractsDirectory": "contracts",
   "solidity.packageDefaultDependenciesDirectory": "node_modules",
-  "solidity.remappings": [
-    "@chainlink/=node_modules/@chainlink/",
-    "@ensdomains/=node_modules/@ensdomains/",
-    "@openzeppelin/=node_modules/@openzeppelin/",
-    "ds-test/=lib/ds-test/src/",
-    "hardhat/=node_modules/hardhat/",
-    "@gearbox-protocol=node_modules/@gearbox-protocol/"
-  ]
+  "solidity.compileUsingRemoteVersion": "v0.8.17",
+  "solidity.formatter": "forge"
 }

--- a/contracts/adapters/AbstractAdapter.sol
+++ b/contracts/adapters/AbstractAdapter.sol
@@ -117,7 +117,7 @@ abstract contract AbstractAdapter is IAdapter, ACLNonReentrantTrait {
         internal
         returns (bytes memory result)
     {
-        return _executeSwap(tokenIn, tokenOut, callData, disableTokenIn, false); // F: [AA-7, AA-13]
+        return _executeSwap(tokenIn, tokenOut, callData, disableTokenIn); // F: [AA-7, AA-13]
     }
 
     /// @dev Executes a swap operation on the target contract from the Credit Account
@@ -132,29 +132,19 @@ abstract contract AbstractAdapter is IAdapter, ACLNonReentrantTrait {
         internal
         returns (bytes memory result)
     {
-        return _executeSwap(tokenIn, tokenOut, callData, disableTokenIn, true); // F: [AA-7, AA-14]
+        _approveToken(tokenIn, type(uint256).max); // F: [AA-14]
+        result = _executeSwap(tokenIn, tokenOut, callData, disableTokenIn); // F: [AA-7, AA-14]
+        _approveToken(tokenIn, 1); // F: [AA-14]
     }
 
     /// @dev Implementation of `_executeSwap...` operations
     /// @dev Kept private as only the internal wrappers are intended to be used
     ///      by inheritors
-    function _executeSwap(
-        address tokenIn,
-        address tokenOut,
-        bytes memory callData,
-        bool disableTokenIn,
-        bool allowTokenIn
-    ) private returns (bytes memory result) {
-        if (allowTokenIn) {
-            _approveToken(tokenIn, type(uint256).max); // F: [AA-14]
-        }
-
+    function _executeSwap(address tokenIn, address tokenOut, bytes memory callData, bool disableTokenIn)
+        private
+        returns (bytes memory result)
+    {
         result = _execute(callData); // F: [AA-13, AA-14]
-
-        if (allowTokenIn) {
-            _approveToken(tokenIn, 1); // F: [AA-14]
-        }
-
         if (disableTokenIn) {
             _disableToken(tokenIn); // F: [AA-13, AA-14]
         }

--- a/contracts/interfaces/IPriceFeedType.sol
+++ b/contracts/interfaces/IPriceFeedType.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Holdings, 2023
+pragma solidity ^0.8.17;
 
 enum PriceFeedType {
     CHAINLINK_ORACLE,
@@ -13,7 +15,6 @@ enum PriceFeedType {
     BOUNDED_ORACLE,
     COMPOSITE_ORACLE,
     AAVE_ORACLE,
-    EULER_ORACLE,
     COMPOUND_ORACLE,
     BALANCER_STABLE_LP_ORACLE,
     BALANCER_WEIGHTED_LP_ORACLE

--- a/contracts/interfaces/adapters/IAdapter.sol
+++ b/contracts/interfaces/adapters/IAdapter.sol
@@ -3,6 +3,7 @@
 // (c) Gearbox Holdings, 2023
 pragma solidity ^0.8.17;
 
+import {IAddressProvider} from "@gearbox-protocol/core-v2/contracts/interfaces/IAddressProvider.sol";
 import {ICreditManagerV2} from "../ICreditManagerV2.sol";
 
 enum AdapterType {
@@ -44,6 +45,9 @@ interface IAdapter is IAdapterExceptions {
 
     /// @notice Address of the contract the adapter is interacting with
     function targetContract() external view returns (address);
+
+    /// @notice Address provider
+    function addressProvider() external view returns (IAddressProvider);
 
     /// @notice Adapter type
     function _gearboxAdapterType() external pure returns (AdapterType);

--- a/contracts/interfaces/adapters/IAdapter.sol
+++ b/contracts/interfaces/adapters/IAdapter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Holdings, 2022
+// (c) Gearbox Holdings, 2023
 pragma solidity ^0.8.17;
 
 import {ICreditManagerV2} from "../ICreditManagerV2.sol";
@@ -25,7 +25,6 @@ enum AdapterType {
     BALANCER_VAULT,
     AAVE_V2_LENDING_POOL,
     AAVE_V2_WRAPPED_ATOKEN,
-    EULER_V1_ETOKEN,
     COMPOUND_V2_CERC20,
     COMPOUND_V2_CETHER
 }

--- a/contracts/test/adapters/AbstractAdapter.t.sol
+++ b/contracts/test/adapters/AbstractAdapter.t.sol
@@ -18,6 +18,7 @@ import {BalanceHelper} from "../helpers/BalanceHelper.sol";
 import {CreditFacadeTestHelper} from "../helpers/CreditFacadeTestHelper.sol";
 
 // EXCEPTIONS
+import {IAdapterExceptions} from "../../interfaces/adapters/IAdapter.sol";
 import {ZeroAddressException} from "../../interfaces/IErrors.sol";
 import {ICreditManagerV2Exceptions} from "../../interfaces/ICreditManagerV2.sol";
 
@@ -132,8 +133,20 @@ contract AbstractAdapterTest is
         adapterMock.execute(DUMB_CALLDATA);
     }
 
-    /// @dev [AA-6]: AbstractAdapter functions revert if user has no credit account
-    function test_AA_06_adapter_reverts_if_user_has_no_credit_account() public {
+    /// @dev [AA-6]: AbstractAdapter _checkToken works correctly
+    function test_AA_06_checkToken_works_correctly() public {
+        assertEq(
+            adapterMock.checkToken(tokenTestSuite.addressOf(Tokens.DAI)),
+            creditManager.tokenMasksMap(tokenTestSuite.addressOf(Tokens.DAI))
+        );
+
+        address token = address(0xdead);
+        evm.expectRevert(abi.encodeWithSelector(IAdapterExceptions.TokenIsNotInAllowedList.selector, token));
+        adapterMock.checkToken(address(0xdead));
+    }
+
+    /// @dev [AA-7]: AbstractAdapter functions revert if user has no credit account
+    function test_AA_07_adapter_reverts_if_user_has_no_credit_account() public {
         evm.expectRevert(HasNoOpenedAccountException.selector);
         adapterMock.creditAccount();
 
@@ -206,8 +219,88 @@ contract AbstractAdapterTest is
         }
     }
 
-    /// @dev [AA-7]: _executeSwapNoApprove correctly passes parameters to CreditManager
-    function test_AA_07_executeSwapNoApprove_correctly_passes_to_credit_manager() public {
+    /// @dev [AA-8]: _approveToken correctly passes parameters to CreditManager
+    function test_AA_08_approveToken_correctly_passes_to_credit_manager() public {
+        _openTestCreditAccount();
+
+        evm.expectCall(
+            address(creditManager),
+            abi.encodeCall(ICreditManagerV2.approveCreditAccount, (address(targetMock), usdc, 10))
+        );
+
+        evm.prank(USER);
+        creditFacade.multicall(
+            multicallBuilder(
+                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.approveToken, (usdc, 10))})
+            )
+        );
+    }
+
+    /// @dev [AA-9]: _enableToken correctly passes parameters to CreditManager
+    function test_AA_09_enableToken_correctly_passes_to_credit_manager() public {
+        _openTestCreditAccount();
+
+        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.checkAndEnableToken, (usdc)));
+
+        evm.prank(USER);
+        creditFacade.multicall(
+            multicallBuilder(
+                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.enableToken, (usdc))})
+            )
+        );
+    }
+
+    /// @dev [AA-10]: _disableToken correctly passes parameters to CreditManager
+    function test_AA_10_disableToken_correctly_passes_to_credit_manager() public {
+        _openTestCreditAccount();
+
+        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.disableToken, (usdc)));
+
+        evm.prank(USER);
+        creditFacade.multicall(
+            multicallBuilder(
+                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.disableToken, (usdc))})
+            )
+        );
+    }
+
+    /// @dev [AA-11]: _changeEnabledTokens correctly passes parameters to CreditManager
+    function test_AA_11_changeEnabledTokens_correctly_passes_to_credit_manager() public {
+        _openTestCreditAccount();
+
+        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.changeEnabledTokens, (1, 2)));
+
+        evm.prank(USER);
+        creditFacade.multicall(
+            multicallBuilder(
+                MultiCall({
+                    target: address(adapterMock),
+                    callData: abi.encodeCall(adapterMock.changeEnabledTokens, (1, 2))
+                })
+            )
+        );
+    }
+
+    /// @dev [AA-12]: _execute correctly passes parameters to CreditManager
+    function test_AA_12_execute_correctly_passes_to_credit_manager() public {
+        _openTestCreditAccount();
+
+        bytes memory DUMB_CALLDATA = abi.encodeWithSignature("hello(string)", "world");
+
+        evm.expectCall(
+            address(creditManager), abi.encodeCall(ICreditManagerV2.executeOrder, (address(targetMock), DUMB_CALLDATA))
+        );
+
+        evm.prank(USER);
+        creditFacade.multicall(
+            multicallBuilder(
+                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.execute, DUMB_CALLDATA)})
+            )
+        );
+    }
+
+    /// @dev [AA-13]: _executeSwapNoApprove correctly passes parameters to CreditManager
+    function test_AA_13_executeSwapNoApprove_correctly_passes_to_credit_manager() public {
         _openTestCreditAccount();
 
         bytes memory DUMB_CALLDATA = abi.encodeWithSignature("hello(string)", "world");
@@ -236,8 +329,8 @@ contract AbstractAdapterTest is
         }
     }
 
-    /// @dev [AA-8]: _executeSwapSafeApprove correctly passes parameters to CreditManager and sets allowance
-    function test_AA_08_executeSwapSafeApprove_correctly_passes_to_credit_manager() public {
+    /// @dev [AA-14]: _executeSwapSafeApprove correctly passes parameters to CreditManager and sets allowance
+    function test_AA_14_executeSwapSafeApprove_correctly_passes_to_credit_manager() public {
         (address ca,) = _openTestCreditAccount();
 
         bytes memory DUMB_CALLDATA = abi.encodeWithSignature("hello(string)", "world");
@@ -276,85 +369,5 @@ contract AbstractAdapterTest is
 
             assertEq(IERC20(usdc).allowance(ca, address(targetMock)), 1, "Incorrect allowance set");
         }
-    }
-
-    /// @dev [AA-9]: _execute correctly passes parameters to CreditManager
-    function test_AA_09_execute_correctly_passes_to_credit_manager() public {
-        _openTestCreditAccount();
-
-        bytes memory DUMB_CALLDATA = abi.encodeWithSignature("hello(string)", "world");
-
-        evm.expectCall(
-            address(creditManager), abi.encodeCall(ICreditManagerV2.executeOrder, (address(targetMock), DUMB_CALLDATA))
-        );
-
-        evm.prank(USER);
-        creditFacade.multicall(
-            multicallBuilder(
-                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.execute, DUMB_CALLDATA)})
-            )
-        );
-    }
-
-    /// @dev [AA-10]: _approveToken correctly passes parameters to CreditManager
-    function test_AA_10_approveToken_correctly_passes_to_credit_manager() public {
-        _openTestCreditAccount();
-
-        evm.expectCall(
-            address(creditManager),
-            abi.encodeCall(ICreditManagerV2.approveCreditAccount, (address(targetMock), usdc, 10))
-        );
-
-        evm.prank(USER);
-        creditFacade.multicall(
-            multicallBuilder(
-                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.approveToken, (usdc, 10))})
-            )
-        );
-    }
-
-    /// @dev [AA-11]: _enableToken correctly passes parameters to CreditManager
-    function test_AA_11_enableToken_correctly_passes_to_credit_manager() public {
-        _openTestCreditAccount();
-
-        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.checkAndEnableToken, (usdc)));
-
-        evm.prank(USER);
-        creditFacade.multicall(
-            multicallBuilder(
-                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.enableToken, (usdc))})
-            )
-        );
-    }
-
-    /// @dev [AA-12]: _disableToken correctly passes parameters to CreditManager
-    function test_AA_12_disableToken_correctly_passes_to_credit_manager() public {
-        _openTestCreditAccount();
-
-        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.disableToken, (usdc)));
-
-        evm.prank(USER);
-        creditFacade.multicall(
-            multicallBuilder(
-                MultiCall({target: address(adapterMock), callData: abi.encodeCall(adapterMock.disableToken, (usdc))})
-            )
-        );
-    }
-
-    /// @dev [AA-13]: _changeEnabledTokens correctly passes parameters to CreditManager
-    function test_AA_13_changeEnabledTokens_correctly_passes_to_credit_manager() public {
-        _openTestCreditAccount();
-
-        evm.expectCall(address(creditManager), abi.encodeCall(ICreditManagerV2.changeEnabledTokens, (1, 2)));
-
-        evm.prank(USER);
-        creditFacade.multicall(
-            multicallBuilder(
-                MultiCall({
-                    target: address(adapterMock),
-                    callData: abi.encodeCall(adapterMock.changeEnabledTokens, (1, 2))
-                })
-            )
-        );
     }
 }

--- a/contracts/test/adapters/AbstractAdapter.t.sol
+++ b/contracts/test/adapters/AbstractAdapter.t.sol
@@ -8,10 +8,12 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {AccountFactory} from "@gearbox-protocol/core-v2/contracts/core/AccountFactory.sol";
 import {CreditFacade} from "../../credit/CreditFacade.sol";
 
+import {IAddressProvider} from "@gearbox-protocol/core-v2/contracts/interfaces/IAddressProvider.sol";
 import {ICreditAccount} from "@gearbox-protocol/core-v2/contracts/interfaces/ICreditAccount.sol";
 import {ICreditFacade, MultiCall} from "@gearbox-protocol/core-v2/contracts/interfaces/ICreditFacade.sol";
 import {ICreditManagerV2, ICreditManagerV2Events} from "../../interfaces/ICreditManagerV2.sol";
 import {ICreditFacadeEvents, ICreditFacadeExceptions} from "../../interfaces/ICreditFacade.sol";
+import {IPool4626} from "../../interfaces/IPool4626.sol";
 
 import "../lib/constants.sol";
 import {BalanceHelper} from "../helpers/BalanceHelper.sol";
@@ -95,18 +97,24 @@ contract AbstractAdapterTest is
 
     /// @dev [AA-1]: AbstractAdapter constructor sets correct values
     function test_AA_01_constructor_sets_correct_values() public {
-        assertEq(address(adapterMock.creditManager()), address(creditManager), "Incorrect Credit Manager");
+        assertEq(address(adapterMock.creditManager()), address(creditManager), "Incorrect credit manager");
+
+        assertEq(
+            address(adapterMock.addressProvider()),
+            IPool4626(creditManager.pool()).addressProvider(),
+            "Incorrect address provider"
+        );
 
         assertEq(adapterMock.targetContract(), address(targetMock), "Incorrect target contract");
     }
 
-    /// @dev [AA-2]: AbstractAdapter constructor reverts when passed a zero-address
+    /// @dev [AA-2]: AbstractAdapter constructor reverts when passed zero-address as target contract
     function test_AA_02_constructor_reverts_on_zero_address() public {
-        evm.expectRevert(ZeroAddressException.selector);
-        AdapterMock am = new AdapterMock(address(0), address(0));
+        evm.expectRevert();
+        new AdapterMock(address(0), address(0));
 
         evm.expectRevert(ZeroAddressException.selector);
-        am = new AdapterMock(address(creditManager), address(0));
+        new AdapterMock(address(creditManager), address(0));
     }
 
     /// @dev [AA-3]: AbstractAdapter uses correct credit facade

--- a/contracts/test/credit/CreditConfigurator.t.sol
+++ b/contracts/test/credit/CreditConfigurator.t.sol
@@ -92,7 +92,10 @@ contract CreditConfiguratorTest is
         TARGET_CONTRACT = address(new TargetContractMock());
 
         adapter1 = new AdapterMock(address(creditManager), TARGET_CONTRACT);
-        adapterDifferentCM = new AdapterMock(address(this), TARGET_CONTRACT);
+
+        adapterDifferentCM = new AdapterMock(
+            address(new CreditFacadeTestSuite(creditConfig).creditManager()), TARGET_CONTRACT
+        );
 
         DUMB_COMPARTIBLE_CONTRACT = address(adapter1);
     }

--- a/contracts/test/mocks/adapters/AdapterMock.sol
+++ b/contracts/test/mocks/adapters/AdapterMock.sol
@@ -24,24 +24,8 @@ contract AdapterMock is AbstractAdapter {
         return _creditAccount();
     }
 
-    function executeSwapNoApprove(address tokenIn, address tokenOut, bytes memory callData, bool disableTokenIn)
-        external
-        creditFacadeOnly
-        returns (bytes memory result)
-    {
-        return _executeSwapNoApprove(tokenIn, tokenOut, callData, disableTokenIn);
-    }
-
-    function executeSwapSafeApprove(address tokenIn, address tokenOut, bytes memory callData, bool disableTokenIn)
-        external
-        creditFacadeOnly
-        returns (bytes memory result)
-    {
-        return _executeSwapSafeApprove(tokenIn, tokenOut, callData, disableTokenIn);
-    }
-
-    function execute(bytes memory callData) external creditFacadeOnly returns (bytes memory result) {
-        result = _execute(callData);
+    function checkToken(address token) external view returns (uint256 tokenMask) {
+        return _checkToken(token);
     }
 
     function approveToken(address token, uint256 amount) external creditFacadeOnly {
@@ -58,6 +42,26 @@ contract AdapterMock is AbstractAdapter {
 
     function changeEnabledTokens(uint256 tokensToEnable, uint256 tokensToDisable) external creditFacadeOnly {
         _changeEnabledTokens(tokensToEnable, tokensToDisable);
+    }
+
+    function execute(bytes memory callData) external creditFacadeOnly returns (bytes memory result) {
+        result = _execute(callData);
+    }
+
+    function executeSwapNoApprove(address tokenIn, address tokenOut, bytes memory callData, bool disableTokenIn)
+        external
+        creditFacadeOnly
+        returns (bytes memory result)
+    {
+        return _executeSwapNoApprove(tokenIn, tokenOut, callData, disableTokenIn);
+    }
+
+    function executeSwapSafeApprove(address tokenIn, address tokenOut, bytes memory callData, bool disableTokenIn)
+        external
+        creditFacadeOnly
+        returns (bytes memory result)
+    {
+        return _executeSwapSafeApprove(tokenIn, tokenOut, callData, disableTokenIn);
     }
 
     fallback() external creditFacadeOnly {

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,14 +1,6 @@
 [profile.default]
 libs = ['lib']
 out = 'forge-out'
-remappings = [
-  'ds-test/=lib/ds-test/src/',
-  '@ensdomains/=node_modules/@ensdomains/',
-  '@openzeppelin/=node_modules/@openzeppelin/',
-  '@chainlink/=node_modules/@chainlink/',
-  'hardhat/=node_modules/hardhat/',
-  '@gearbox-protocol=node_modules/@gearbox-protocol/'
-]
 solc_version = '0.8.17'
 src = 'contracts'
 optimizer_runs = 20000

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,5 @@
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/
+@chainlink/=node_modules/@chainlink/
+@openzeppelin/=node_modules/@openzeppelin/
+@gearbox-protocol=node_modules/@gearbox-protocol/


### PR DESCRIPTION
In this PR:
* add `_checkToken` and `addressProvider` to `AbstractAdapter`
* `AbstractAdapter` now inherits `ACLNonReentrantTrait`
* remove Euler adapter and price feed types
* fix Solidity remappings