### PR TITLE
feat: controller rework

### DIFF
--- a/contracts/governance/ControllerTimelockV3.sol
+++ b/contracts/governance/ControllerTimelockV3.sol
@@ -423,7 +423,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
         }
 
         if (msg.sender != qtd.executor) {
-            revert CallerNotExecutorException();
+            revert CallerNotExecutorException(); // U: [CT-09]
         }
 
         address target = qtd.target;

--- a/contracts/governance/ControllerTimelockV3.sol
+++ b/contracts/governance/ControllerTimelockV3.sol
@@ -18,17 +18,15 @@ import {ILPPriceFeedV2} from "@gearbox-protocol/core-v2/contracts/interfaces/ILP
 ///      manipulate system parameters, within set boundaries.
 ///      This is mostly related to risk parameters that should ideally
 ///      be adjusted frequently, or periodic tasks (e.g., updating price feed limiters)
-///      that are too trivial to employ full governance
+///      that are too trivial to employ full governance for.
 /// @dev The contract uses PolicyManager as its underlying engine
 ///      to set parameter change boundaries and conditions. In order to
 ///      schedule a change for a particular contract / function combination
-///      a policy needs to be defined for it. See more in `PolicyManager`
+///      a policy needs to be defined for it. The policy also determines the
+///      address that can change a particular parameter. See more in `PolicyManager`
 contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @notice Period before a mature transaction becomes stale
     uint256 public constant GRACE_PERIOD = 14 days;
-
-    /// @notice Admin address that can schedule controller transactions
-    address public admin;
 
     /// @notice Admin address that can cancel transactions
     address public vetoAdmin;
@@ -41,19 +39,9 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
     /// @dev Constructor
     /// @param _addressProvider Address of the contract address repository
-    /// @param _admin Admin of the controller contract that can schedule transactions
     /// @param _vetoAdmin Admin that can cancel transactions
-    constructor(address _addressProvider, address _admin, address _vetoAdmin) PolicyManagerV3(_addressProvider) {
-        admin = _admin;
+    constructor(address _addressProvider, address _vetoAdmin) PolicyManagerV3(_addressProvider) {
         vetoAdmin = _vetoAdmin;
-    }
-
-    /// @dev Allows access to functions only to the controller admin
-    modifier adminOnly() {
-        if (msg.sender != admin) {
-            revert CallerNotAdminException();
-        }
-        _;
     }
 
     /// @dev Allows access to function only to veto admin
@@ -68,10 +56,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(creditManager), "EXPIRATION_DATE") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to update the expiration date for
     /// @param expirationDate The new expiration date
-    function setExpirationDate(address creditManager, uint40 expirationDate)
-        external
-        adminOnly // U: [CT-01]
-    {
+    function setExpirationDate(address creditManager, uint40 expirationDate) external {
         ICreditFacadeV3 creditFacade = ICreditFacadeV3(ICreditManagerV3(creditManager).creditFacade());
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
         IPoolV3 pool = IPoolV3(ICreditManagerV3(creditManager).pool());
@@ -97,10 +82,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(priceFeed), "LP_PRICE_FEED_LIMITER") to be enabled, otherwise auto-fails the check
     /// @param priceFeed The price feed to update the limiter in
     /// @param lowerBound The new limiter lower bound value
-    function setLPPriceFeedLimiter(address priceFeed, uint256 lowerBound)
-        external
-        adminOnly // U: [CT-02]
-    {
+    function setLPPriceFeedLimiter(address priceFeed, uint256 lowerBound) external {
         uint256 currentLowerBound = ILPPriceFeedV2(priceFeed).lowerBound();
 
         if (!_checkPolicy(priceFeed, "LP_PRICE_FEED_LIMITER", currentLowerBound, lowerBound)) {
@@ -114,10 +96,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(creditManager), "MAX_DEBT_PER_BLOCK_MULTIPLIER") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to update the multiplier for
     /// @param multiplier The new multiplier value
-    function setMaxDebtPerBlockMultiplier(address creditManager, uint8 multiplier)
-        external
-        adminOnly // U: [CT-03]
-    {
+    function setMaxDebtPerBlockMultiplier(address creditManager, uint8 multiplier) external {
         ICreditFacadeV3 creditFacade = ICreditFacadeV3(ICreditManagerV3(creditManager).creditFacade());
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
 
@@ -142,10 +121,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(creditManager), "MIN_DEBT") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to update the limits for
     /// @param minDebt The new minimal debt amount
-    function setMinDebtLimit(address creditManager, uint128 minDebt)
-        external
-        adminOnly // U: [CT-04A]
-    {
+    function setMinDebtLimit(address creditManager, uint128 minDebt) external {
         ICreditFacadeV3 creditFacade = ICreditFacadeV3(ICreditManagerV3(creditManager).creditFacade());
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
 
@@ -166,10 +142,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(creditManager), "MAX_DEBT") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to update the limits for
     /// @param maxDebt The maximal debt amount
-    function setMaxDebtLimit(address creditManager, uint128 maxDebt)
-        external
-        adminOnly // U: [CT-04B]
-    {
+    function setMaxDebtLimit(address creditManager, uint128 maxDebt) external {
         ICreditFacadeV3 creditFacade = ICreditFacadeV3(ICreditManagerV3(creditManager).creditFacade());
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
 
@@ -190,10 +163,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(creditManager), "CREDIT_MANAGER_DEBT_LIMIT") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to update the debt limit for
     /// @param debtLimit The new debt limit
-    function setCreditManagerDebtLimit(address creditManager, uint256 debtLimit)
-        external
-        adminOnly // U: [CT-05]
-    {
+    function setCreditManagerDebtLimit(address creditManager, uint256 debtLimit) external {
         ICreditFacadeV3 creditFacade = ICreditFacadeV3(ICreditManagerV3(creditManager).creditFacade());
 
         if (creditFacade.trackTotalDebt()) {
@@ -243,10 +213,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
         uint16 liquidationThresholdFinal,
         uint40 rampStart,
         uint24 rampDuration
-    )
-        external
-        adminOnly // U: [CT-06]
-    {
+    ) external {
         bytes32 policyHash = keccak256(abi.encode(_group[creditManager], _group[token], "TOKEN_LT"));
 
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
@@ -270,10 +237,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @dev Requires the policy for keccak(group(contractManager), "FORBID_ADAPTER") to be enabled, otherwise auto-fails the check
     /// @param creditManager Adress of CM to forbid a contract for
     /// @param adapter Address of adapter to forbid
-    function forbidAdapter(address creditManager, address adapter)
-        external
-        adminOnly // U: [CT-10]
-    {
+    function forbidAdapter(address creditManager, address adapter) external {
         bytes32 policyHash = keccak256(abi.encode(_group[creditManager], "FORBID_ADAPTER"));
 
         address creditConfigurator = ICreditManagerV3(creditManager).creditConfigurator();
@@ -291,10 +255,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @param pool Pool to update the limit for
     /// @param token Token to update the limit for
     /// @param limit The new value of the limit
-    function setTokenLimit(address pool, address token, uint96 limit)
-        external
-        adminOnly // U: [CT-11]
-    {
+    function setTokenLimit(address pool, address token, uint96 limit) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], _group[token], "TOKEN_LIMIT"));
 
         address poolQuotaKeeper = IPoolV3(pool).poolQuotaKeeper();
@@ -316,7 +277,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @param pool Pool to update the limit for
     /// @param token Token to update the limit for
     /// @param quotaIncreaseFee The new value of the fee in bp
-    function setTokenQuotaIncreaseFee(address pool, address token, uint16 quotaIncreaseFee) external adminOnly {
+    function setTokenQuotaIncreaseFee(address pool, address token, uint16 quotaIncreaseFee) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], _group[token], "TOKEN_QUOTA_INCREASE_FEE"));
 
         address poolQuotaKeeper = IPoolV3(pool).poolQuotaKeeper();
@@ -337,7 +298,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @notice Queues a transaction to set a new total debt limit for the entire pool
     /// @param pool Pool to update the limit for
     /// @param newLimit The new value of the limit
-    function setTotalDebtLimit(address pool, uint256 newLimit) external adminOnly {
+    function setTotalDebtLimit(address pool, uint256 newLimit) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], "TOTAL_DEBT_LIMIT"));
 
         uint256 totalDebtLimitOld = IPoolV3(pool).totalDebtLimit();
@@ -352,7 +313,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @notice Queues a transaction to set a new withdrawal fee in a pool
     /// @param pool Pool to update the limit for
     /// @param newFee The new value of the fee in bp
-    function setWithdrawFee(address pool, uint256 newFee) external adminOnly {
+    function setWithdrawFee(address pool, uint256 newFee) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], "WITHDRAW_FEE"));
 
         uint256 withdrawFeeOld = IPoolV3(pool).withdrawFee();
@@ -368,7 +329,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @param pool Pool to update the limit for
     /// @param token Token to set the new fee for
     /// @param rate The new minimal rate
-    function setMinQuotaRate(address pool, address token, uint16 rate) external adminOnly {
+    function setMinQuotaRate(address pool, address token, uint16 rate) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], _group[token], "TOKEN_QUOTA_MIN_RATE"));
 
         address poolQuotaKeeper = IPoolV3(pool).poolQuotaKeeper();
@@ -392,7 +353,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     /// @param pool Pool to update the limit for
     /// @param token Token to set the new fee for
     /// @param rate The new minimal rate
-    function setMaxQuotaRate(address pool, address token, uint16 rate) external adminOnly {
+    function setMaxQuotaRate(address pool, address token, uint16 rate) external {
         bytes32 policyHash = keccak256(abi.encode(_group[pool], _group[token], "TOKEN_QUOTA_MAX_RATE"));
 
         address poolQuotaKeeper = IPoolV3(pool).poolQuotaKeeper();
@@ -419,12 +380,26 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     function _queueTransaction(address target, string memory signature, bytes memory data) internal returns (bytes32) {
         uint256 eta = block.timestamp + delay;
 
-        bytes32 txHash = keccak256(abi.encode(target, signature, data, eta));
+        bytes32 txHash = keccak256(abi.encode(msg.sender, target, signature, data, eta));
 
-        queuedTransactions[txHash] =
-            QueuedTransactionData({queued: true, target: target, eta: uint40(eta), signature: signature, data: data});
+        queuedTransactions[txHash] = QueuedTransactionData({
+            queued: true,
+            executor: msg.sender,
+            target: target,
+            eta: uint40(eta),
+            signature: signature,
+            data: data
+        });
 
-        emit QueueTransaction(txHash, target, signature, data, uint40(eta));
+        emit QueueTransaction({
+            txHash: txHash,
+            executor: msg.sender,
+            target: target,
+            signature: signature,
+            data: data,
+            eta: uint40(eta)
+        });
+
         return txHash;
     }
 
@@ -440,14 +415,15 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
     /// @dev Executes a queued transaction
     /// @param txHash Hash of the transaction to be executed
-    function executeTransaction(bytes32 txHash)
-        external
-        adminOnly // U: [CT-09]
-    {
+    function executeTransaction(bytes32 txHash) external {
         QueuedTransactionData memory qtd = queuedTransactions[txHash];
 
         if (!qtd.queued) {
             revert TxNotQueuedException(); // U: [CT-07]
+        }
+
+        if (msg.sender != qtd.executor) {
+            revert CallerNotExecutorException();
         }
 
         address target = qtd.target;
@@ -479,15 +455,6 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
     }
 
     /// CONFIGURATION
-
-    /// @dev Sets a new risk admin address
-    function setAdmin(address newAdmin)
-        external
-        configuratorOnly // U: [CT-08]
-    {
-        admin = newAdmin; // U: [CT-08]
-        emit SetAdmin(newAdmin); // U: [CT-08]
-    }
 
     /// @dev Sets a new veto admin address
     function setVetoAdmin(address newAdmin)

--- a/contracts/governance/GaugeV3.sol
+++ b/contracts/governance/GaugeV3.sol
@@ -250,15 +250,9 @@ contract GaugeV3 is IGaugeV3, IVotingContractV3, ACLNonReentrantTrait {
     function changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate)
         external
         nonZeroAddress(token) // U:[GA-04]
-        configuratorOnly // U:[GA-03]
+        controllerOnly // U:[GA-03]
     {
         _changeQuotaTokenRateParams(token, minRate, maxRate);
-    }
-
-    /// @dev Changes the rate params for a quoted token
-    /// @param minRate The minimal interest rate paid on token's quotas
-    function changeQuotaTokenMinRate(address token, uint16 minRate) external nonZeroAddress(token) controllerOnly {
-        _changeQuotaTokenRateParams(token, minRate, quotaRateParams[token].maxRate); // U:[GA-06]
     }
 
     function _changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate) internal {

--- a/contracts/governance/PolicyManagerV3.sol
+++ b/contracts/governance/PolicyManagerV3.sol
@@ -13,6 +13,9 @@ struct Policy {
     /// @dev Determines whether the policy is enabled
     ///      A disabled policy will auto-fail the policy check
     bool enabled;
+    /// @dev The admin responsible that can change the parameter under
+    ///      the given policy
+    address admin;
     /// @dev Bitmask of flags that determine which policy checks to apply on parameter change:
     ///      0 - check exact value
     ///      1 - check min value
@@ -114,6 +117,8 @@ contract PolicyManagerV3 is ACLNonReentrantTrait {
         Policy storage policy = _policies[policyHash];
 
         if (!policy.enabled) return false; // F: [PM-02]
+
+        if (policy.admin != msg.sender) return false;
 
         uint8 flags = policy.flags;
 

--- a/contracts/interfaces/IControllerTimelockV3.sol
+++ b/contracts/interfaces/IControllerTimelockV3.sol
@@ -21,7 +21,7 @@ interface IControllerTimelockV3Events {
 
     /// @dev Emits when a transaction is queued
     event QueueTransaction(
-        bytes32 indexed txHash, address executor, address target, string signature, bytes data, uint40 eta
+        bytes32 indexed txHash, address indexed executor, address target, string signature, bytes data, uint40 eta
     );
 
     /// @dev Emits when a transaction is executed

--- a/contracts/interfaces/IControllerTimelockV3.sol
+++ b/contracts/interfaces/IControllerTimelockV3.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.17;
 
 struct QueuedTransactionData {
     bool queued;
+    address executor;
     address target;
     uint40 eta;
     string signature;
@@ -12,9 +13,6 @@ struct QueuedTransactionData {
 }
 
 interface IControllerTimelockV3Events {
-    /// @dev Emits when the admin of the controller is updated
-    event SetAdmin(address indexed newAdmin);
-
     /// @dev Emits when the veto admin of the controller is updated
     event SetVetoAdmin(address indexed newAdmin);
 
@@ -22,7 +20,9 @@ interface IControllerTimelockV3Events {
     event SetDelay(uint256 newDelay);
 
     /// @dev Emits when a transaction is queued
-    event QueueTransaction(bytes32 indexed txHash, address target, string signature, bytes data, uint40 eta);
+    event QueueTransaction(
+        bytes32 indexed txHash, address executor, address target, string signature, bytes data, uint40 eta
+    );
 
     /// @dev Emits when a transaction is executed
     event ExecuteTransaction(bytes32 indexed txHash);
@@ -32,8 +32,9 @@ interface IControllerTimelockV3Events {
 }
 
 interface IControllerTimelockV3Errors {
-    /// @dev Thrown when the access-restricted function is called by other than the admin
-    error CallerNotAdminException();
+    /// @dev Thrown when an address that is not the designated executor
+    ///      attempts to execute a transaction
+    error CallerNotExecutorException();
 
     /// @dev Thrown when the access-restricted function is called by other than the veto admin
     error CallerNotVetoAdminException();

--- a/contracts/test/unit/governance/Gauge.unit.t.sol
+++ b/contracts/test/unit/governance/Gauge.unit.t.sol
@@ -92,7 +92,7 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         vm.expectRevert(CallerNotConfiguratorException.selector);
         gauge.addQuotaToken(DUMB_ADDRESS, 0, 0);
 
-        vm.expectRevert(CallerNotConfiguratorException.selector);
+        vm.expectRevert(CallerNotControllerException.selector);
         gauge.changeQuotaTokenRateParams(DUMB_ADDRESS, 0, 0);
     }
 
@@ -187,46 +187,6 @@ contract GauageTest is TestHelper, IGaugeV3Events {
 
         assertEq(_minRate, minRate, "Incorrect minRate");
         assertEq(_maxRate, maxRate, "Incorrect maxRate");
-
-        assertEq(_totalVotesLpSide, totalVotesLpSide, "Incorrect totalVotesLpSide");
-        assertEq(_totalVotesCaSide, totalVotesCaSide, "Incorrect totalVotesCaSide");
-    }
-
-    /// @dev U:[GA-07]: changeQuotaTokenRateParams works as expected
-    function test_U_GA_07_changeQuotaTokenMinRate_works_as_expected() public {
-        address token = makeAddr("TOKEN");
-        uint16 minRate = 100;
-        uint16 maxRate = 500;
-
-        // Case: it reverts if token is not added before
-        vm.expectRevert(TokenNotAllowedException.selector);
-        vm.prank(CONFIGURATOR);
-        gauge.changeQuotaTokenMinRate(token, minRate);
-
-        // Case: it updates rates only if token added
-
-        uint96 totalVotesLpSide = 9323;
-        uint96 totalVotesCaSide = 12323;
-
-        gauge.setQuotaRateParams({
-            token: token,
-            minRate: minRate + 1312,
-            maxRate: maxRate + 1923,
-            totalVotesLpSide: totalVotesLpSide,
-            totalVotesCaSide: totalVotesCaSide
-        });
-
-        vm.expectEmit(true, true, false, true);
-        emit SetQuotaTokenParams({token: token, minRate: minRate, maxRate: maxRate + 1923});
-
-        vm.prank(CONFIGURATOR);
-        gauge.changeQuotaTokenMinRate(token, minRate);
-
-        (uint16 _minRate, uint16 _maxRate, uint96 _totalVotesLpSide, uint96 _totalVotesCaSide) =
-            gauge.quotaRateParams(token);
-
-        assertEq(_minRate, minRate, "Incorrect minRate");
-        assertEq(_maxRate, maxRate + 1923, "Incorrect maxRate");
 
         assertEq(_totalVotesLpSide, totalVotesLpSide, "Incorrect totalVotesLpSide");
         assertEq(_totalVotesCaSide, totalVotesCaSide, "Incorrect totalVotesCaSide");

--- a/contracts/test/unit/governance/PolicyManager.t.sol
+++ b/contracts/test/unit/governance/PolicyManager.t.sol
@@ -38,6 +38,7 @@ contract PolicyManagerTest is Test {
     function test_PM_01_setPolicy_getPolicy_setGroup_getGroup_work_correctly() public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 2 + 4 + 16,
             exactValue: 15,
             minValue: 10,
@@ -61,6 +62,8 @@ contract PolicyManagerTest is Test {
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
 
         assertTrue(policy2.enabled, "Enabled not set by setPolicy");
+
+        assertEq(policy2.admin, FRIEND, "Admin was not set correctly");
 
         assertEq(policy2.flags, 22, "Flags are incorrect");
 
@@ -98,6 +101,7 @@ contract PolicyManagerTest is Test {
     function test_PM_02_checkPolicy_false_on_disabled() public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 2 + 4 + 16,
             exactValue: 15,
             minValue: 10,
@@ -117,6 +121,7 @@ contract PolicyManagerTest is Test {
         vm.prank(CONFIGURATOR);
         policyManager.disablePolicy(bytes32(uint256(1)));
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), 0, 1));
     }
 
@@ -124,6 +129,7 @@ contract PolicyManagerTest is Test {
     function test_PM_03_checkPolicy_exactValue_works_correctly(uint256 newValue) public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 1,
             exactValue: 15,
             minValue: 0,
@@ -140,6 +146,7 @@ contract PolicyManagerTest is Test {
         vm.prank(CONFIGURATOR);
         policyManager.setPolicy(bytes32(uint256(1)), policy);
 
+        vm.prank(FRIEND);
         assertTrue(newValue == 15 || !policyManager.checkPolicy(bytes32(uint256(1)), 0, newValue));
     }
 
@@ -147,6 +154,7 @@ contract PolicyManagerTest is Test {
     function test_PM_04_checkPolicy_minValue_works_correctly(uint256 minValue, uint256 newValue) public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 2,
             exactValue: 0,
             minValue: minValue,
@@ -163,6 +171,7 @@ contract PolicyManagerTest is Test {
         vm.prank(CONFIGURATOR);
         policyManager.setPolicy(bytes32(uint256(1)), policy);
 
+        vm.prank(FRIEND);
         assertTrue(newValue >= minValue || !policyManager.checkPolicy(bytes32(uint256(1)), 0, newValue));
     }
 
@@ -170,6 +179,7 @@ contract PolicyManagerTest is Test {
     function test_PM_05_checkPolicy_maxValue_works_correctly(uint256 maxValue, uint256 newValue) public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 4,
             exactValue: 0,
             minValue: 0,
@@ -186,6 +196,7 @@ contract PolicyManagerTest is Test {
         vm.prank(CONFIGURATOR);
         policyManager.setPolicy(bytes32(uint256(1)), policy);
 
+        vm.prank(FRIEND);
         assertTrue(newValue <= maxValue || !policyManager.checkPolicy(bytes32(uint256(1)), 0, newValue));
     }
 
@@ -193,6 +204,7 @@ contract PolicyManagerTest is Test {
     function test_PM_06_checkPolicy_correctly_sets_reference_point() public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 8,
             exactValue: 0,
             minValue: 0,
@@ -209,6 +221,7 @@ contract PolicyManagerTest is Test {
         vm.prank(CONFIGURATOR);
         policyManager.setPolicy(bytes32(uint256(1)), policy);
 
+        vm.prank(FRIEND);
         policyManager.checkPolicy(bytes32(uint256(1)), 20, 20);
 
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
@@ -228,6 +241,7 @@ contract PolicyManagerTest is Test {
     ) public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 8,
             exactValue: 0,
             minValue: 0,
@@ -246,18 +260,21 @@ contract PolicyManagerTest is Test {
 
         uint256 diff = newValue1 > oldValue ? newValue1 - oldValue : oldValue - newValue1;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), oldValue, newValue1) || diff >= minChange);
 
         vm.warp(block.timestamp + 1);
 
         diff = newValue2 > oldValue ? newValue2 - oldValue : oldValue - newValue2;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue1, newValue2) || diff >= minChange);
 
         vm.warp(block.timestamp + 1 days);
 
         diff = newValue3 > newValue2 ? newValue3 - newValue2 : newValue2 - newValue3;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue2, newValue3) || diff >= minChange);
 
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
@@ -277,6 +294,7 @@ contract PolicyManagerTest is Test {
     ) public {
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 16,
             exactValue: 0,
             minValue: 0,
@@ -295,18 +313,21 @@ contract PolicyManagerTest is Test {
 
         uint256 diff = newValue1 > oldValue ? newValue1 - oldValue : oldValue - newValue1;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), oldValue, newValue1) || diff <= maxChange);
 
         vm.warp(block.timestamp + 1);
 
         diff = newValue2 > oldValue ? newValue2 - oldValue : oldValue - newValue2;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue1, newValue2) || diff <= maxChange);
 
         vm.warp(block.timestamp + 1 days);
 
         diff = newValue3 > newValue2 ? newValue3 - newValue2 : newValue2 - newValue3;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue2, newValue3) || diff <= maxChange);
 
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
@@ -334,6 +355,7 @@ contract PolicyManagerTest is Test {
 
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 32,
             exactValue: 0,
             minValue: 0,
@@ -353,11 +375,13 @@ contract PolicyManagerTest is Test {
         uint256 pctDiff =
             (newValue1 > oldValue ? newValue1 - oldValue : oldValue - newValue1) * PERCENTAGE_FACTOR / oldValue;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), oldValue, newValue1) || pctDiff >= minPctChange);
         vm.warp(block.timestamp + 1);
 
         pctDiff = (newValue2 > oldValue ? newValue2 - oldValue : oldValue - newValue2) * PERCENTAGE_FACTOR / oldValue;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue1, newValue2) || pctDiff >= minPctChange);
 
         vm.warp(block.timestamp + 1 days);
@@ -365,6 +389,7 @@ contract PolicyManagerTest is Test {
         pctDiff =
             (newValue3 > newValue2 ? newValue3 - newValue2 : newValue2 - newValue3) * PERCENTAGE_FACTOR / newValue2;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue2, newValue3) || pctDiff >= minPctChange);
 
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
@@ -392,6 +417,7 @@ contract PolicyManagerTest is Test {
 
         Policy memory policy = Policy({
             enabled: false,
+            admin: FRIEND,
             flags: 64,
             exactValue: 0,
             minValue: 0,
@@ -411,11 +437,13 @@ contract PolicyManagerTest is Test {
         uint256 pctDiff =
             (newValue1 > oldValue ? newValue1 - oldValue : oldValue - newValue1) * PERCENTAGE_FACTOR / oldValue;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), oldValue, newValue1) || pctDiff <= maxPctChange);
         vm.warp(block.timestamp + 1);
 
         pctDiff = (newValue2 > oldValue ? newValue2 - oldValue : oldValue - newValue2) * PERCENTAGE_FACTOR / oldValue;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue1, newValue2) || pctDiff <= maxPctChange);
 
         vm.warp(block.timestamp + 1 days);
@@ -423,6 +451,7 @@ contract PolicyManagerTest is Test {
         pctDiff =
             (newValue3 > newValue2 ? newValue3 - newValue2 : newValue2 - newValue3) * PERCENTAGE_FACTOR / newValue2;
 
+        vm.prank(FRIEND);
         assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), newValue2, newValue3) || pctDiff <= maxPctChange);
 
         Policy memory policy2 = policyManager.getPolicy(bytes32(uint256(1)));
@@ -430,5 +459,33 @@ contract PolicyManagerTest is Test {
         assertEq(policy2.referencePoint, newValue2, "Incorrect reference point");
 
         assertEq(policy2.referencePointTimestampLU, block.timestamp, "Incorrect timestamp LU");
+    }
+
+    /// @dev [PM-11]: checkPolicy returns false on caller not being admin
+    function test_PM_11_checkPolicy_returns_false_on_wrong_caller() public {
+        Policy memory policy = Policy({
+            enabled: false,
+            admin: FRIEND,
+            flags: 0,
+            exactValue: 0,
+            minValue: 0,
+            maxValue: 0,
+            referencePoint: 0,
+            referencePointUpdatePeriod: 0,
+            referencePointTimestampLU: 0,
+            minPctChange: 0,
+            maxPctChange: 0,
+            minChange: 0,
+            maxChange: 0
+        });
+
+        vm.prank(CONFIGURATOR);
+        policyManager.setPolicy(bytes32(uint256(1)), policy);
+
+        vm.prank(USER);
+        assertTrue(!policyManager.checkPolicy(bytes32(uint256(1)), 0, 0));
+
+        vm.prank(FRIEND);
+        assertTrue(policyManager.checkPolicy(bytes32(uint256(1)), 0, 0));
     }
 }

--- a/contracts/traits/ACLNonReentrantTrait.sol
+++ b/contracts/traits/ACLNonReentrantTrait.sol
@@ -22,34 +22,49 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
     /// @notice Emitted when new external controller is set
     event NewController(address indexed newController);
 
-    /// @notice Whether contract has an external controller set
-    bool public externalController;
-
     /// @notice External controller address
     address public controller;
 
-    /// @dev Ensures that function caller is external controller (if it is set) or configurator
+    /// @dev Ensures that function caller is external controller or configurator
     modifier controllerOnly() {
+        _ensureControllerOrConfigurator();
+        _;
+    }
+
+    /// @dev Reverts if the caller is not controller or configurator
+    /// @dev Used to cut contract size on modifiers
+    function _ensureControllerOrConfigurator() internal view {
         if (msg.sender != controller && !_isConfigurator({account: msg.sender})) {
             revert CallerNotControllerException();
         }
-        _;
     }
 
     /// @dev Ensures that function caller has pausable admin role
     modifier pausableAdminsOnly() {
+        _ensurePausableAdmin();
+        _;
+    }
+
+    /// @dev Reverts if the caller is not pausable admin
+    /// @dev Used to cut contract size on modifiers
+    function _ensurePausableAdmin() internal view {
         if (!_isPausableAdmin({account: msg.sender})) {
             revert CallerNotPausableAdminException();
         }
-        _;
     }
 
     /// @dev Ensures that function caller has unpausable admin role
     modifier unpausableAdminsOnly() {
+        _ensureUnpausableAdmin();
+        _;
+    }
+
+    /// @dev Reverts if the caller is not unpausable admin
+    /// @dev Used to cut contract size on modifiers
+    function _ensureUnpausableAdmin() internal view {
         if (!_isUnpausableAdmin({account: msg.sender})) {
             revert CallerNotUnpausableAdminException();
         }
-        _;
     }
 
     /// @notice Constructor
@@ -70,7 +85,6 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @notice Sets new external controller, can only be called by configurator
     function setController(address newController) external configuratorOnly {
-        externalController = !_isConfigurator(newController);
         controller = newController;
         emit NewController(newController);
     }

--- a/contracts/traits/ACLNonReentrantTrait.sol
+++ b/contracts/traits/ACLNonReentrantTrait.sol
@@ -27,13 +27,13 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @dev Ensures that function caller is external controller or configurator
     modifier controllerOnly() {
-        _ensureControllerOrConfigurator();
+        _ensureCallerIsControllerOrConfigurator();
         _;
     }
 
     /// @dev Reverts if the caller is not controller or configurator
     /// @dev Used to cut contract size on modifiers
-    function _ensureControllerOrConfigurator() internal view {
+    function _ensureCallerIsControllerOrConfigurator() internal view {
         if (msg.sender != controller && !_isConfigurator({account: msg.sender})) {
             revert CallerNotControllerException();
         }
@@ -41,13 +41,13 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @dev Ensures that function caller has pausable admin role
     modifier pausableAdminsOnly() {
-        _ensurePausableAdmin();
+        _ensureCallerIsPausableAdmin();
         _;
     }
 
     /// @dev Reverts if the caller is not pausable admin
     /// @dev Used to cut contract size on modifiers
-    function _ensurePausableAdmin() internal view {
+    function _ensureCallerIsPausableAdmin() internal view {
         if (!_isPausableAdmin({account: msg.sender})) {
             revert CallerNotPausableAdminException();
         }
@@ -55,13 +55,13 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @dev Ensures that function caller has unpausable admin role
     modifier unpausableAdminsOnly() {
-        _ensureUnpausableAdmin();
+        _ensureCallerIsUnpausableAdmin();
         _;
     }
 
     /// @dev Reverts if the caller is not unpausable admin
     /// @dev Used to cut contract size on modifiers
-    function _ensureUnpausableAdmin() internal view {
+    function _ensureCallerIsUnpausableAdmin() internal view {
         if (!_isUnpausableAdmin({account: msg.sender})) {
             revert CallerNotUnpausableAdminException();
         }
@@ -85,6 +85,7 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @notice Sets new external controller, can only be called by configurator
     function setController(address newController) external configuratorOnly {
+        if (controller == newController) return;
         controller = newController;
         emit NewController(newController);
     }

--- a/contracts/traits/ACLNonReentrantTrait.sol
+++ b/contracts/traits/ACLNonReentrantTrait.sol
@@ -30,14 +30,8 @@ abstract contract ACLNonReentrantTrait is ACLTrait, Pausable, ReentrancyGuardTra
 
     /// @dev Ensures that function caller is external controller (if it is set) or configurator
     modifier controllerOnly() {
-        if (externalController) {
-            if (msg.sender != controller) {
-                revert CallerNotControllerException();
-            }
-        } else {
-            if (!_isConfigurator({account: msg.sender})) {
-                revert CallerNotControllerException();
-            }
+        if (msg.sender != controller && !_isConfigurator({account: msg.sender})) {
+            revert CallerNotControllerException();
         }
         _;
     }

--- a/contracts/traits/ACLTrait.sol
+++ b/contracts/traits/ACLTrait.sol
@@ -24,10 +24,16 @@ abstract contract ACLTrait is SanityCheckTrait {
 
     /// @dev Ensures that function caller has configurator role
     modifier configuratorOnly() {
+        _ensureConfigurator();
+        _;
+    }
+
+    /// @dev Reverts if the caller is not the configurator
+    /// @dev Used to cut contract size on modifiers
+    function _ensureConfigurator() internal view {
         if (!_isConfigurator({account: msg.sender})) {
             revert CallerNotConfiguratorException();
         }
-        _;
     }
 
     /// @dev Checks whether given account has configurator role

--- a/contracts/traits/ACLTrait.sol
+++ b/contracts/traits/ACLTrait.sol
@@ -24,13 +24,13 @@ abstract contract ACLTrait is SanityCheckTrait {
 
     /// @dev Ensures that function caller has configurator role
     modifier configuratorOnly() {
-        _ensureConfigurator();
+        _ensureCallerIsConfigurator();
         _;
     }
 
     /// @dev Reverts if the caller is not the configurator
     /// @dev Used to cut contract size on modifiers
-    function _ensureConfigurator() internal view {
+    function _ensureCallerIsConfigurator() internal view {
         if (!_isConfigurator({account: msg.sender})) {
             revert CallerNotConfiguratorException();
         }

--- a/contracts/traits/ReentrancyGuardTrait.sol
+++ b/contracts/traits/ReentrancyGuardTrait.sol
@@ -18,7 +18,7 @@ abstract contract ReentrancyGuardTrait {
     /// `private` function that does the actual work.
     modifier nonReentrant() {
         // On the first call to nonReentrant, _notEntered will be true
-        require(_reentrancyStatus != ENTERED, "ReentrancyGuard: reentrant call");
+        _ensureNotEntered();
 
         // Any calls to nonReentrant after this point will fail
         _reentrancyStatus = ENTERED;
@@ -28,5 +28,11 @@ abstract contract ReentrancyGuardTrait {
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
         _reentrancyStatus = NOT_ENTERED;
+    }
+
+    /// @dev Reverts if the contract is currently entered
+    /// @dev /// @dev Used to cut contract size on modifiers
+    function _ensureNotEntered() internal view {
+        require(_reentrancyStatus != ENTERED, "ReentrancyGuard: reentrant call");
     }
 }

--- a/contracts/traits/ReentrancyGuardTrait.sol
+++ b/contracts/traits/ReentrancyGuardTrait.sol
@@ -31,7 +31,7 @@ abstract contract ReentrancyGuardTrait {
     }
 
     /// @dev Reverts if the contract is currently entered
-    /// @dev /// @dev Used to cut contract size on modifiers
+    /// @dev Used to cut contract size on modifiers
     function _ensureNotEntered() internal view {
         require(_reentrancyStatus != ENTERED, "ReentrancyGuard: reentrant call");
     }


### PR DESCRIPTION
Controller-related logic reworked:
1) `controllerOnly` functions now allow access to configurator regardless of whether the controller is set
2) PolicyManager now has `admin` field in `Policy` and checks it in `checkPolicy`. This allows to configure admins per configured parameter, which enables having different functions in the same contract (i.e. CreditConfigurator) under different admins. The execution of a transaction is always performed by the address that scheduled it, i.e. the admin in the corresponding policy