### PR TITLE
feat: controller improvements

### DIFF
--- a/contracts/governance/ControllerTimelockV3.sol
+++ b/contracts/governance/ControllerTimelockV3.sol
@@ -355,7 +355,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
         address gauge = IPoolQuotaKeeperV3(poolQuotaKeeper).gauge();
 
-        (uint16 minRateCurrent, uint16 maxRateCurrent,,) = IGaugeV3(gauge).quotaRateParams(token);
+        (uint16 minRateCurrent,,,) = IGaugeV3(gauge).quotaRateParams(token);
 
         if (!_checkPolicy(policyHash, uint256(minRateCurrent), uint256(rate))) {
             revert ParameterChecksFailedException(); // U: [CT-15A]
@@ -363,8 +363,8 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
         _queueTransaction({
             target: gauge,
-            signature: "changeQuotaTokenRateParams(address,uint16,uint16)",
-            data: abi.encode(token, rate, maxRateCurrent)
+            signature: "changeQuotaMinRate(address,uint16)",
+            data: abi.encode(token, rate)
         }); // U: [CT-15A]
     }
 
@@ -381,7 +381,7 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
         address gauge = IPoolQuotaKeeperV3(poolQuotaKeeper).gauge();
 
-        (uint16 minRateCurrent, uint16 maxRateCurrent,,) = IGaugeV3(gauge).quotaRateParams(token);
+        (, uint16 maxRateCurrent,,) = IGaugeV3(gauge).quotaRateParams(token);
 
         if (!_checkPolicy(policyHash, uint256(maxRateCurrent), uint256(rate))) {
             revert ParameterChecksFailedException(); // U: [CT-15B]
@@ -389,8 +389,8 @@ contract ControllerTimelockV3 is PolicyManagerV3, IControllerTimelockV3 {
 
         _queueTransaction({
             target: gauge,
-            signature: "changeQuotaTokenRateParams(address,uint16,uint16)",
-            data: abi.encode(token, minRateCurrent, rate)
+            signature: "changeQuotaMaxRate(address,uint16)",
+            data: abi.encode(token, rate)
         }); // U: [CT-15B]
     }
 

--- a/contracts/governance/GaugeV3.sol
+++ b/contracts/governance/GaugeV3.sol
@@ -244,9 +244,31 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
         external
         override
         nonZeroAddress(token) // U:[GA-04]
-        controllerOnly // U:[GA-03]
+        configuratorOnly // U:[GA-03]
     {
         _changeQuotaTokenRateParams(token, minRate, maxRate);
+    }
+
+    /// @dev Changes the min rate for a quoted token
+    /// @param minRate The minimal interest rate paid on token's quotas
+    function changeQuotaMinRate(address token, uint16 minRate)
+        external
+        override
+        nonZeroAddress(token) // U: TODO
+        controllerOnly // U: TODO
+    {
+        _changeQuotaTokenRateParams(token, minRate, quotaRateParams[token].maxRate);
+    }
+
+    /// @dev Changes the max rate for a quoted token
+    /// @param maxRate The maximal interest rate paid on token's quotas
+    function changeQuotaMaxRate(address token, uint16 maxRate)
+        external
+        override
+        nonZeroAddress(token) // U: TODO
+        controllerOnly // U: TODO
+    {
+        _changeQuotaTokenRateParams(token, quotaRateParams[token].minRate, maxRate);
     }
 
     /// @dev Implementation of `changeQuotaTokenRateParams`

--- a/contracts/governance/GaugeV3.sol
+++ b/contracts/governance/GaugeV3.sol
@@ -237,25 +237,13 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
         emit AddQuotaToken({token: token, minRate: minRate, maxRate: maxRate}); // U:[GA-05]
     }
 
-    /// @dev Changes the rate params for a quoted token
-    /// @param minRate The minimal interest rate paid on token's quotas
-    /// @param maxRate The maximal interest rate paid on token's quotas
-    function changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate)
-        external
-        override
-        nonZeroAddress(token) // U:[GA-04]
-        configuratorOnly // U:[GA-03]
-    {
-        _changeQuotaTokenRateParams(token, minRate, maxRate);
-    }
-
     /// @dev Changes the min rate for a quoted token
     /// @param minRate The minimal interest rate paid on token's quotas
     function changeQuotaMinRate(address token, uint16 minRate)
         external
         override
-        nonZeroAddress(token) // U: TODO
-        controllerOnly // U: TODO
+        nonZeroAddress(token) // U: [GA-04]
+        controllerOnly // U: [GA-03]
     {
         _changeQuotaTokenRateParams(token, minRate, quotaRateParams[token].maxRate);
     }
@@ -265,24 +253,24 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
     function changeQuotaMaxRate(address token, uint16 maxRate)
         external
         override
-        nonZeroAddress(token) // U: TODO
-        controllerOnly // U: TODO
+        nonZeroAddress(token) // U: [GA-04]
+        controllerOnly // U: [GA-03]
     {
         _changeQuotaTokenRateParams(token, quotaRateParams[token].minRate, maxRate);
     }
 
     /// @dev Implementation of `changeQuotaTokenRateParams`
     function _changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate) internal {
-        if (!isTokenAdded(token)) revert TokenNotAllowedException(); // U:[GA-06]
+        if (!isTokenAdded(token)) revert TokenNotAllowedException(); // U:[GA-06A, GA-06B]
 
         _checkParams(minRate, maxRate); // U:[GA-04]
 
-        QuotaRateParams storage qrp = quotaRateParams[token]; // U:[GA-06]
+        QuotaRateParams storage qrp = quotaRateParams[token]; // U:[GA-06A, GA-06B]
         if (minRate == qrp.minRate && maxRate == qrp.maxRate) return;
-        qrp.minRate = minRate; // U:[GA-06]
-        qrp.maxRate = maxRate; // U:[GA-06]
+        qrp.minRate = minRate; // U:[GA-06A, GA-06B]
+        qrp.maxRate = maxRate; // U:[GA-06A, GA-06B]
 
-        emit SetQuotaTokenParams({token: token, minRate: minRate, maxRate: maxRate}); // U:[GA-06]
+        emit SetQuotaTokenParams({token: token, minRate: minRate, maxRate: maxRate}); // U:[GA-06A, GA-06B]
     }
 
     /// @dev Checks that given min and max rate are correct (`0 < minRate <= maxRate`)

--- a/contracts/governance/PolicyManagerV3.sol
+++ b/contracts/governance/PolicyManagerV3.sol
@@ -120,12 +120,12 @@ abstract contract PolicyManagerV3 is ACLNonReentrantTrait {
         return _policies[policyHash].delay;
     }
 
-    /// @dev Returns policy transaction delay, with policy retrieved based on contract and parameter name
+    /// @dev Returns policy transaction delay, with policy retrieved based on policy UID
     function _getPolicyDelay(bytes32 policyHash) internal view returns (uint256) {
         return _policies[policyHash].delay;
     }
 
-    /// @dev Performs parameter checks, with policy retrieved based on policy UID
+    /// @dev Performs parameter checks, with policy retrieved based on contract and parameter name
     function _checkPolicy(address contractAddress, string memory paramName, uint256 oldValue, uint256 newValue)
         internal
         returns (bool)

--- a/contracts/interfaces/IControllerTimelockV3.sol
+++ b/contracts/interfaces/IControllerTimelockV3.sol
@@ -18,9 +18,6 @@ interface IControllerTimelockV3Events {
     /// @notice Emitted when the veto admin of the controller is updated
     event SetVetoAdmin(address indexed newAdmin);
 
-    /// @notice Emitted when the delay is changed
-    event SetDelay(uint256 newDelay);
-
     /// @notice Emitted when a transaction is queued
     event QueueTransaction(
         bytes32 indexed txHash, address indexed executor, address target, string signature, bytes data, uint40 eta
@@ -96,9 +93,5 @@ interface IControllerTimelockV3 is IControllerTimelockV3Events, IVersion {
 
     function vetoAdmin() external view returns (address);
 
-    function delay() external view returns (uint256);
-
     function setVetoAdmin(address newAdmin) external;
-
-    function setDelay(uint256 newDelay) external;
 }

--- a/contracts/interfaces/IGaugeV3.sol
+++ b/contracts/interfaces/IGaugeV3.sol
@@ -73,8 +73,6 @@ interface IGaugeV3 is IGaugeV3Events, IVotingContractV3, IVersion {
 
     function addQuotaToken(address token, uint16 minRate, uint16 maxRate) external;
 
-    function changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate) external;
-
     function changeQuotaMinRate(address token, uint16 minRate) external;
 
     function changeQuotaMaxRate(address token, uint16 maxRate) external;

--- a/contracts/interfaces/IGaugeV3.sol
+++ b/contracts/interfaces/IGaugeV3.sol
@@ -74,4 +74,8 @@ interface IGaugeV3 is IGaugeV3Events, IVotingContractV3, IVersion {
     function addQuotaToken(address token, uint16 minRate, uint16 maxRate) external;
 
     function changeQuotaTokenRateParams(address token, uint16 minRate, uint16 maxRate) external;
+
+    function changeQuotaMinRate(address token, uint16 minRate) external;
+
+    function changeQuotaMaxRate(address token, uint16 maxRate) external;
 }

--- a/contracts/test/suites/PoolFactory.sol
+++ b/contracts/test/suites/PoolFactory.sol
@@ -106,7 +106,6 @@ contract PoolFactory is Test {
                     address token = tokensTestSuite.addressOf(quotaLimits[i].token);
 
                     vm.startPrank(CONFIGURATOR);
-                    poolQuotaKeeper.addQuotaToken(token);
                     poolQuotaKeeper.setTokenLimit(token, quotaLimits[i].limit);
                     poolQuotaKeeper.setTokenQuotaIncreaseFee(token, quotaLimits[i].quotaIncreaseFee);
                     vm.stopPrank();

--- a/contracts/test/unit/governance/ControllerTimelock.t.sol
+++ b/contracts/test/unit/governance/ControllerTimelock.t.sol
@@ -1283,8 +1283,8 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             abi.encode(
                 admin,
                 gauge,
-                "changeQuotaTokenRateParams(address,uint16,uint16)",
-                abi.encode(token, uint16(15), uint16(20)),
+                "changeQuotaMinRate(address,uint16)",
+                abi.encode(token, uint16(15)),
                 block.timestamp + 1 days
             )
         );
@@ -1294,15 +1294,15 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             txHash,
             admin,
             gauge,
-            "changeQuotaTokenRateParams(address,uint16,uint16)",
-            abi.encode(token, uint16(15), uint16(20)),
+            "changeQuotaMinRate(address,uint16)",
+            abi.encode(token, uint16(15)),
             uint40(block.timestamp + 1 days)
         );
 
         vm.prank(admin);
         controllerTimelock.setMinQuotaRate(pool, token, 15);
 
-        vm.expectCall(gauge, abi.encodeCall(GaugeV3.changeQuotaTokenRateParams, (token, 15, 20)));
+        vm.expectCall(gauge, abi.encodeCall(GaugeV3.changeQuotaMinRate, (token, 15)));
 
         vm.warp(block.timestamp + 1 days);
 
@@ -1374,8 +1374,8 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             abi.encode(
                 admin,
                 gauge,
-                "changeQuotaTokenRateParams(address,uint16,uint16)",
-                abi.encode(token, uint16(10), uint16(25)),
+                "changeQuotaMaxRate(address,uint16)",
+                abi.encode(token, uint16(25)),
                 block.timestamp + 1 days
             )
         );
@@ -1385,15 +1385,15 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             txHash,
             admin,
             gauge,
-            "changeQuotaTokenRateParams(address,uint16,uint16)",
-            abi.encode(token, uint16(10), uint16(25)),
+            "changeQuotaMaxRate(address,uint16)",
+            abi.encode(token, uint16(25)),
             uint40(block.timestamp + 1 days)
         );
 
         vm.prank(admin);
         controllerTimelock.setMaxQuotaRate(pool, token, 25);
 
-        vm.expectCall(gauge, abi.encodeCall(GaugeV3.changeQuotaTokenRateParams, (token, 10, 25)));
+        vm.expectCall(gauge, abi.encodeCall(GaugeV3.changeQuotaMaxRate, (token, 25)));
 
         vm.warp(block.timestamp + 1 days);
 

--- a/contracts/test/unit/governance/ControllerTimelock.t.sol
+++ b/contracts/test/unit/governance/ControllerTimelock.t.sol
@@ -112,6 +112,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: block.timestamp + 5,
             minValue: 0,
@@ -203,6 +204,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 7,
             minValue: 0,
@@ -271,6 +273,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 2 days,
             flags: 1,
             exactValue: 4,
             minValue: 0,
@@ -309,7 +312,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
                 creditConfigurator,
                 "setMaxDebtPerBlockMultiplier(uint8)",
                 abi.encode(4),
-                block.timestamp + 1 days
+                block.timestamp + 2 days
             )
         );
 
@@ -320,7 +323,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             creditConfigurator,
             "setMaxDebtPerBlockMultiplier(uint8)",
             abi.encode(4),
-            uint40(block.timestamp + 1 days)
+            uint40(block.timestamp + 2 days)
         );
 
         vm.prank(admin);
@@ -330,7 +333,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             creditConfigurator, abi.encodeWithSelector(ICreditConfiguratorV3.setMaxDebtPerBlockMultiplier.selector, 4)
         );
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 2 days);
 
         vm.prank(admin);
         controllerTimelock.executeTransaction(txHash);
@@ -351,6 +354,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 3 days,
             flags: 1,
             exactValue: 15,
             minValue: 0,
@@ -384,7 +388,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
 
         // VERIFY THAT THE FUNCTION IS QUEUED AND EXECUTED CORRECTLY
         bytes32 txHash = keccak256(
-            abi.encode(admin, creditConfigurator, "setMinDebtLimit(uint128)", abi.encode(15), block.timestamp + 1 days)
+            abi.encode(admin, creditConfigurator, "setMinDebtLimit(uint128)", abi.encode(15), block.timestamp + 3 days)
         );
 
         vm.expectEmit(true, false, false, true);
@@ -394,7 +398,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             creditConfigurator,
             "setMinDebtLimit(uint128)",
             abi.encode(15),
-            uint40(block.timestamp + 1 days)
+            uint40(block.timestamp + 3 days)
         );
 
         vm.prank(admin);
@@ -402,7 +406,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
 
         vm.expectCall(creditConfigurator, abi.encodeWithSelector(ICreditConfiguratorV3.setMinDebtLimit.selector, 15));
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 3 days);
 
         vm.prank(admin);
         controllerTimelock.executeTransaction(txHash);
@@ -423,6 +427,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 25,
             minValue: 0,
@@ -499,6 +504,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 2e18,
             minValue: 0,
@@ -579,6 +585,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 2e18,
             minValue: 0,
@@ -664,6 +671,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 6000,
             minValue: 0,
@@ -776,6 +784,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: block.timestamp + 5,
             minValue: 0,
@@ -832,10 +841,6 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         vm.prank(USER);
         controllerTimelock.setVetoAdmin(DUMB_ADDRESS);
 
-        vm.expectRevert(CallerNotConfiguratorException.selector);
-        vm.prank(USER);
-        controllerTimelock.setDelay(5);
-
         vm.expectEmit(true, false, false, false);
         emit SetVetoAdmin(DUMB_ADDRESS);
 
@@ -843,14 +848,6 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         controllerTimelock.setVetoAdmin(DUMB_ADDRESS);
 
         assertEq(controllerTimelock.vetoAdmin(), DUMB_ADDRESS, "Veto admin address was not set");
-
-        vm.expectEmit(false, false, false, true);
-        emit SetDelay(5);
-
-        vm.prank(CONFIGURATOR);
-        controllerTimelock.setDelay(5);
-
-        assertEq(controllerTimelock.delay(), 5, "Delay was not set");
     }
 
     /// @dev U:[CT-9]: executeTransaction works correctly
@@ -871,6 +868,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
             enabled: false,
             admin: FRIEND,
             flags: 1,
+            delay: 2 days,
             exactValue: expirationDate,
             minValue: 0,
             maxValue: 0,
@@ -893,7 +891,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
                 creditConfigurator,
                 "setExpirationDate(uint40)",
                 abi.encode(expirationDate),
-                block.timestamp + 1 days
+                block.timestamp + 2 days
             )
         );
 
@@ -944,6 +942,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 0,
             exactValue: 0,
             minValue: 0,
@@ -1024,6 +1023,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 20,
             minValue: 0,
@@ -1102,6 +1102,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 2e18,
             minValue: 0,
@@ -1168,6 +1169,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 20,
             minValue: 0,
@@ -1247,6 +1249,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 15,
             minValue: 0,
@@ -1338,6 +1341,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 1,
             exactValue: 25,
             minValue: 0,
@@ -1421,6 +1425,7 @@ contract ControllerTimelockTest is Test, IControllerTimelockV3Events {
         Policy memory policy = Policy({
             enabled: false,
             admin: admin,
+            delay: 1 days,
             flags: 0,
             exactValue: 0,
             minValue: 0,

--- a/contracts/test/unit/governance/Gauge.unit.t.sol
+++ b/contracts/test/unit/governance/Gauge.unit.t.sol
@@ -87,8 +87,14 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         vm.expectRevert(CallerNotConfiguratorException.selector);
         gauge.addQuotaToken(DUMB_ADDRESS, 0, 0);
 
-        vm.expectRevert(CallerNotControllerException.selector);
+        vm.expectRevert(CallerNotConfiguratorException.selector);
         gauge.changeQuotaTokenRateParams(DUMB_ADDRESS, 0, 0);
+
+        vm.expectRevert(CallerNotControllerException.selector);
+        gauge.changeQuotaMinRate(DUMB_ADDRESS, 0);
+
+        vm.expectRevert(CallerNotControllerException.selector);
+        gauge.changeQuotaMaxRate(DUMB_ADDRESS, 0);
     }
 
     /// @dev U:[GA-04]: addQuotaToken and changeQuotaTokenRateParams reverts for incorrect params
@@ -121,6 +127,12 @@ contract GauageTest is TestHelper, IGaugeV3Events {
 
         vm.expectRevert(IncorrectParameterException.selector);
         gauge.changeQuotaTokenRateParams(token, 5, 2);
+
+        vm.expectRevert(ZeroAddressException.selector);
+        gauge.changeQuotaMinRate(address(0), 0);
+
+        vm.expectRevert(ZeroAddressException.selector);
+        gauge.changeQuotaMaxRate(address(0), 0);
 
         vm.stopPrank();
     }

--- a/contracts/test/unit/governance/Gauge.unit.t.sol
+++ b/contracts/test/unit/governance/Gauge.unit.t.sol
@@ -87,9 +87,6 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         vm.expectRevert(CallerNotConfiguratorException.selector);
         gauge.addQuotaToken(DUMB_ADDRESS, 0, 0);
 
-        vm.expectRevert(CallerNotConfiguratorException.selector);
-        gauge.changeQuotaTokenRateParams(DUMB_ADDRESS, 0, 0);
-
         vm.expectRevert(CallerNotControllerException.selector);
         gauge.changeQuotaMinRate(DUMB_ADDRESS, 0);
 
@@ -97,8 +94,8 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         gauge.changeQuotaMaxRate(DUMB_ADDRESS, 0);
     }
 
-    /// @dev U:[GA-04]: addQuotaToken and changeQuotaTokenRateParams reverts for incorrect params
-    function test_U_GA_04_addQuotaToken_and_changeQuotaTokenRateParams_reverts_for_incorrect_params() public {
+    /// @dev U:[GA-04]: addQuotaToken and quota rate function revert for incorrect params
+    function test_U_GA_04_addQuotaToken_reverts_for_incorrect_params() public {
         address token = DUMB_ADDRESS;
         vm.startPrank(CONFIGURATOR);
 
@@ -120,19 +117,19 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         gauge.addQuotaToken(token, 0, 0);
 
         vm.expectRevert(ZeroAddressException.selector);
-        gauge.changeQuotaTokenRateParams(address(0), 0, 0);
-
-        vm.expectRevert(IncorrectParameterException.selector);
-        gauge.changeQuotaTokenRateParams(token, 0, 0);
-
-        vm.expectRevert(IncorrectParameterException.selector);
-        gauge.changeQuotaTokenRateParams(token, 5, 2);
-
-        vm.expectRevert(ZeroAddressException.selector);
         gauge.changeQuotaMinRate(address(0), 0);
 
         vm.expectRevert(ZeroAddressException.selector);
         gauge.changeQuotaMaxRate(address(0), 0);
+
+        vm.expectRevert(IncorrectParameterException.selector);
+        gauge.changeQuotaMinRate(token, 0);
+
+        vm.expectRevert(IncorrectParameterException.selector);
+        gauge.changeQuotaMaxRate(token, 0);
+
+        vm.expectRevert(IncorrectParameterException.selector);
+        gauge.changeQuotaMinRate(token, 5);
 
         vm.stopPrank();
     }
@@ -177,16 +174,15 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         gauge.addQuotaToken(token2, minRate, maxRate);
     }
 
-    /// @dev U:[GA-06]: changeQuotaTokenRateParams works as expected
-    function test_U_GA_06_changeQuotaTokenRateParams_works_as_expected() public {
+    /// @dev U:[GA-06A]: changeQuotaMinRate works as expected
+    function test_U_GA_06A_changeQuotaMinRate_works_as_expected() public {
         address token = makeAddr("TOKEN");
         uint16 minRate = 100;
-        uint16 maxRate = 500;
 
         // Case: it reverts if token is not added before
         vm.expectRevert(TokenNotAllowedException.selector);
         vm.prank(CONFIGURATOR);
-        gauge.changeQuotaTokenRateParams(token, minRate, maxRate);
+        gauge.changeQuotaMinRate(token, minRate);
 
         // Case: it updates rates only if token added
 
@@ -196,25 +192,56 @@ contract GauageTest is TestHelper, IGaugeV3Events {
         gauge.setQuotaRateParams({
             token: token,
             minRate: minRate + 1312,
-            maxRate: maxRate + 1923,
+            maxRate: 2000,
             totalVotesLpSide: totalVotesLpSide,
             totalVotesCaSide: totalVotesCaSide
         });
 
         vm.expectEmit(true, true, false, true);
-        emit SetQuotaTokenParams({token: token, minRate: minRate, maxRate: maxRate});
+        emit SetQuotaTokenParams({token: token, minRate: minRate, maxRate: 2000});
 
         vm.prank(CONFIGURATOR);
-        gauge.changeQuotaTokenRateParams(token, minRate, maxRate);
+        gauge.changeQuotaMinRate(token, minRate);
 
         (uint16 _minRate, uint16 _maxRate, uint96 _totalVotesLpSide, uint96 _totalVotesCaSide) =
             gauge.quotaRateParams(token);
 
         assertEq(_minRate, minRate, "Incorrect minRate");
-        assertEq(_maxRate, maxRate, "Incorrect maxRate");
+    }
 
-        assertEq(_totalVotesLpSide, totalVotesLpSide, "Incorrect totalVotesLpSide");
-        assertEq(_totalVotesCaSide, totalVotesCaSide, "Incorrect totalVotesCaSide");
+    /// @dev U:[GA-06B]: changeQuotaMaxRate works as expected
+    function test_U_GA_06B_changeQuotaMaxRate_works_as_expected() public {
+        address token = makeAddr("TOKEN");
+        uint16 maxRate = 3000;
+
+        // Case: it reverts if token is not added before
+        vm.expectRevert(TokenNotAllowedException.selector);
+        vm.prank(CONFIGURATOR);
+        gauge.changeQuotaMaxRate(token, maxRate);
+
+        // Case: it updates rates only if token added
+
+        uint96 totalVotesLpSide = 9323;
+        uint96 totalVotesCaSide = 12323;
+
+        gauge.setQuotaRateParams({
+            token: token,
+            minRate: 500,
+            maxRate: maxRate + 1000,
+            totalVotesLpSide: totalVotesLpSide,
+            totalVotesCaSide: totalVotesCaSide
+        });
+
+        vm.expectEmit(true, true, false, true);
+        emit SetQuotaTokenParams({token: token, minRate: 500, maxRate: maxRate});
+
+        vm.prank(CONFIGURATOR);
+        gauge.changeQuotaMaxRate(token, maxRate);
+
+        (uint16 _minRate, uint16 _maxRate, uint96 _totalVotesLpSide, uint96 _totalVotesCaSide) =
+            gauge.quotaRateParams(token);
+
+        assertEq(_maxRate, maxRate, "Incorrect maxRate");
     }
 
     /// @dev U:[GA-08]: isTokenAdded works as expected

--- a/contracts/test/unit/governance/PolicyManager.t.sol
+++ b/contracts/test/unit/governance/PolicyManager.t.sol
@@ -42,6 +42,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 2 + 4 + 16,
             exactValue: 15,
             minValue: 10,
@@ -111,6 +112,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 2 + 4 + 16,
             exactValue: 15,
             minValue: 10,
@@ -142,6 +144,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 1,
             exactValue: 15,
             minValue: 0,
@@ -167,6 +170,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 2,
             exactValue: 0,
             minValue: minValue,
@@ -192,6 +196,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 4,
             exactValue: 0,
             minValue: 0,
@@ -217,6 +222,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 8,
             exactValue: 0,
             minValue: 0,
@@ -254,6 +260,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 8,
             exactValue: 0,
             minValue: 0,
@@ -307,6 +314,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 16,
             exactValue: 0,
             minValue: 0,
@@ -368,6 +376,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 32,
             exactValue: 0,
             minValue: 0,
@@ -430,6 +439,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 64,
             exactValue: 0,
             minValue: 0,
@@ -478,6 +488,7 @@ contract PolicyManagerTest is Test {
         Policy memory policy = Policy({
             enabled: false,
             admin: FRIEND,
+            delay: 1 days,
             flags: 0,
             exactValue: 0,
             minValue: 0,


### PR DESCRIPTION
1) Transaction delays are now policy-dependent, instead of 1 global delay per contract
2) Two functions `changeQuotaMinRate` and `changeQuotaMaxRate` were added in addition to `changeQuotaTokenRateParams`, and controller functions were adjusted accordingly