### PR TITLE
fix: credit contracts cleanup

### DIFF
--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -41,12 +41,9 @@ import "../interfaces/IAddressProviderV3.sol";
 // EXCEPTIONS
 import "../interfaces/IExceptions.sol";
 
-/// @title CreditConfiguratorV3
-/// @notice This contract is used to configure Credit Managers and is the only one with the privilege
-///         to call access-restricted functions
-/// @dev All functions can only by called by the Configurator as per ACL.
-///      Credit Manager blindly executes all requests (in nearly all cases) from Credit Configurator,
-///      so most sanity checks are performed here.
+/// @title Credit configurator V3
+/// @notice Provides funcionality to configure various aspects of credit manager and facade's behavior
+/// @dev Most of the functions can only be accessed by configurator or timelock controller
 contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
     using EnumerableSet for EnumerableSet.AddressSet;
     using Address for address;

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -3,6 +3,7 @@
 // (c) Gearbox Foundation, 2023.
 pragma solidity ^0.8.17;
 
+// THIRD-PARTY
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
@@ -52,47 +53,40 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
     using BitMask for uint256;
 
     /// @notice Contract version
-    uint256 public constant version = 3_00;
+    uint256 public constant override version = 3_00;
 
-    /// @notice Address provider (needed for upgrading the Price Oracle)
+    /// @notice Address provider contract address
     address public immutable override addressProvider;
 
-    /// @notice Address of the Credit Manager
+    /// @notice Credit manager address
     address public immutable override creditManager;
 
-    /// @notice Address of the Credit Manager's underlying asset
+    /// @notice Underlying token address
     address public immutable override underlying;
 
-    /// @notice Set of allowed contracts
-    EnumerableSet.AddressSet private allowedAdaptersSet;
+    /// @dev Set of allowed contracts
+    EnumerableSet.AddressSet internal allowedAdaptersSet;
 
-    /// @notice Set of emergency liquidators
-    EnumerableSet.AddressSet private emergencyLiquidatorsSet;
+    /// @dev Set of emergency liquidators
+    EnumerableSet.AddressSet internal emergencyLiquidatorsSet;
 
-    /// @notice Sanity check to verify that the token is not the underlying
+    /// @dev Ensures that function is not called for underlying token
     modifier nonUnderlyingTokenOnly(address token) {
         _revertIfUnderlyingToken(token);
         _;
     }
 
-    function _revertIfUnderlyingToken(address token) internal view {
-        if (token == underlying) revert TokenNotAllowedException();
-    }
-
-    /// @notice Constructor has a special role in Credit Manager deployment
-    /// For newly deployed CMs, this is where the initial configuration is performed.
-    /// The correct deployment flow is as follows:
-    ///
-    /// 1. Configures CreditManagerV3 fee parameters and sets underlying LT
-    /// 2. Adds collateral tokens and sets their LTs
-    /// 3. Connects creditFacade and priceOracle to the Credit Manager
-    /// 4. Sets itself as creditConfigurator in Credit Manager
-    ///
-    /// For existing Credit Manager the CC will only migrate some parameters from the previous Credit Configurator,
-    /// and will otherwise keep the existing CM configuration intact.
-    /// @param _creditManager CreditManagerV3 contract instance
-    /// @param _creditFacade CreditFacadeV3 contract instance
-    /// @param opts Configuration parameters for CreditManagerV3
+    /// @notice Constructor
+    ///         - For a newly deployed credit manager, performs initial configuration:
+    ///           * sets its fee parameters to default values and adds collateral tokens
+    ///           * connects the credit facade and sets debt limits in it
+    ///         - For an existing credit manager, simply copies lists of allowed adapters and emergency liquidators
+    ///           from the currently connected credit configurator
+    /// @param _creditManager Credit manager to connect to
+    /// @param _creditFacade Facade to connect to the credit manager (ignored for existing credit managers)
+    /// @param opts Credit manager configuration paramaters, see `CreditManagerOpts` for details
+    /// @dev When deploying a new credit suite, this contract must be deployed via `create2`. By the moment of deployment,
+    ///      new credit manager must already have pre-computed address of this contract set as credit configurator.
     constructor(CreditManagerV3 _creditManager, CreditFacadeV3 _creditFacade, CreditManagerOpts memory opts)
         ACLNonReentrantTrait(_creditManager.addressProvider())
     {
@@ -104,15 +98,8 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
 
         address currentConfigurator = CreditManagerV3(creditManager).creditConfigurator(); // I:[CC-41]
 
+        // existing credit manager
         if (currentConfigurator != address(this)) {
-            // DEPLOYED FOR EXISTING CREDIT MANAGER
-            // In the case where the CC is deployed for the existing Credit Manager,
-            // we only need to copy several array parameters from the last CC,
-            // but the existing configs must be kept intact otherwise
-            // 1. Allowed contracts set stores all the connected third-party contracts - currently only used
-            //    to retrieve externally
-            // 2. Emergency liquidator set stores all emergency liquidators - used for parameter migration when changing the Credit Facade
-
             address[] memory allowedAdaptersPrev = CreditConfiguratorV3(currentConfigurator).allowedAdapters(); // I:[CC-29]
             uint256 len = allowedAdaptersPrev.length;
             unchecked {
@@ -128,10 +115,9 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
                     emergencyLiquidatorsSet.add(emergencyLiquidatorsPrev[i]); // I:[CC-29]
                 }
             }
-        } else {
-            // DEPLOYED FOR NEW CREDIT MANAGER
-
-            // Sets liquidation discounts and fees for the Credit Manager
+        }
+        // new credit manager
+        else {
             _setFees({
                 feeInterest: DEFAULT_FEE_INTEREST,
                 feeLiquidation: DEFAULT_FEE_LIQUIDATION,
@@ -140,8 +126,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
                 liquidationDiscountExpired: PERCENTAGE_FACTOR - DEFAULT_LIQUIDATION_PREMIUM_EXPIRED
             }); // I:[CC-1]
 
-            // Adds collateral tokens and sets their liquidation thresholds
-            // The underlying must not be in this list, since its LT is set separately in _setFees
             uint256 len = opts.collateralTokens.length;
             unchecked {
                 for (uint256 i = 0; i < len; ++i) {
@@ -156,29 +140,33 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
                 }
             }
 
-            // Connects creditFacade and priceOracle
             CreditManagerV3(creditManager).setCreditFacade(address(_creditFacade)); // I:[CC-1]
 
             emit SetCreditFacade(address(_creditFacade)); // I:[CC-1A]
             emit SetPriceOracle(CreditManagerV3(creditManager).priceOracle()); // I:[CC-1A]
 
-            // Sets the max debt per block multiplier
-            // This parameter determines the maximal new debt per block as a factor of
-            // maximal Credit Account debt - essentially a cap on the number of new Credit Accounts per block
             _setMaxDebtPerBlockMultiplier(address(_creditFacade), uint8(DEFAULT_LIMIT_PER_BLOCK_MULTIPLIER)); // I:[CC-1]
-
-            // Sets the borrowing limits per Credit Account
             _setLimits({_creditFacade: address(_creditFacade), minDebt: opts.minDebt, maxDebt: opts.maxDebt}); // I:[CC-1]
         }
     }
 
-    //
-    // CONFIGURATION: TOKEN MANAGEMENT
-    //
+    /// @notice Returns the facade currently connected to the credit manager
+    function creditFacade() public view override returns (address) {
+        return CreditManagerV3(creditManager).creditFacade();
+    }
 
-    /// @notice Adds token to the list of allowed collateral tokens, and sets the LT
-    /// @param token Address of token to be added
-    /// @param liquidationThreshold Liquidation threshold for account health calculations
+    // ------ //
+    // TOKENS //
+    // ------ //
+
+    /// @notice Makes token recognizable as collateral in the credit manager and sets its liquidation threshold
+    /// @notice In case token is quoted in the quota keeper, also makes it quoted in the credit manager
+    /// @param token Token to add
+    /// @param liquidationThreshold LT to set in bps
+    /// @dev Reverts if `token` is not a valid ERC-20 token
+    /// @dev Reverts if `token` does not have a price feed in the price oracle
+    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `liquidationThreshold` is greater than underlying's LT
     function addCollateralToken(address token, uint16 liquidationThreshold)
         external
         override
@@ -189,37 +177,35 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _setLiquidationThreshold({token: token, liquidationThreshold: liquidationThreshold}); // I:[CC-4]
     }
 
-    /// @dev Makes all sanity checks and adds the token to the collateral token list
-    /// @param token Address of token to be added
+    /// @dev `addCollateralToken` implementation
     function _addCollateralToken(address token) internal {
-        // Checks that the token is a contract
         if (!token.isContract()) revert AddressIsNotContractException(token); // I:[CC-3]
 
-        // Checks that the contract has balanceOf method
         try IERC20(token).balanceOf(address(this)) returns (uint256) {}
         catch {
             revert IncorrectTokenContractException(); // I:[CC-3]
         }
 
-        // Checks that the token has a correct priceFeed in priceOracle
         try IPriceOracleBase(CreditManagerV3(creditManager).priceOracle()).convertToUSD({amount: WAD, token: token})
         returns (uint256) {} catch {
             revert IncorrectPriceFeedException(); // I:[CC-3]
         }
 
-        // сreditManager has an additional check that the token is not added yet
         CreditManagerV3(creditManager).addToken({token: token}); // I:[CC-4]
 
         if (_isQuotedToken(token)) {
             _makeTokenQuoted(token);
         }
 
-        emit AllowToken({token: token}); // I:[CC-4]
+        emit AddCollateralToken({token: token}); // I:[CC-4]
     }
 
-    /// @notice Sets a liquidation threshold for any token except the underlying
-    /// @param token Token address
-    /// @param liquidationThreshold in PERCENTAGE_FORMAT (100% = 10000)
+    /// @notice Sets token's liquidation threshold
+    /// @param token Token to set the LT for
+    /// @param liquidationThreshold LT to set in bps
+    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `token` is not recognized as collateral in the credit manager
+    /// @dev Reverts if `liquidationThreshold` is greater than underlying's LT
     function setLiquidationThreshold(address token, uint16 liquidationThreshold)
         external
         override
@@ -228,8 +214,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _setLiquidationThreshold({token: token, liquidationThreshold: liquidationThreshold}); // I:[CC-5]
     }
 
-    /// @dev IMPLEMENTAION: setLiquidationThreshold
-    // Checks that the token is not underlying, since its LT is determined by Credit Manager params
+    /// @dev `setLiquidationThreshold` implementation
     function _setLiquidationThreshold(address token, uint16 liquidationThreshold)
         internal
         nonUnderlyingTokenOnly(token)
@@ -237,15 +222,10 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         (, uint16 ltUnderlying) =
             CreditManagerV3(creditManager).collateralTokenByMask({tokenMask: UNDERLYING_TOKEN_MASK});
 
-        // Sanity check for the liquidation threshold. The LT should be less than underlying
         if (liquidationThreshold > ltUnderlying) {
             revert IncorrectLiquidationThresholdException(); // I:[CC-5]
         }
 
-        /// When the LT of a token is set directly, we set the parameters
-        /// as if it was a ramp from `liquidationThreshold` to `liquidationThreshold`
-        /// starting in far future. This ensures that the LT function in Credit Manager
-        /// will always return `liquidationThreshold` until the parameters are changed
         CreditManagerV3(creditManager).setCollateralTokenData({
             token: token,
             ltInitial: liquidationThreshold,
@@ -257,10 +237,14 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         emit SetTokenLiquidationThreshold({token: token, liquidationThreshold: liquidationThreshold}); // I:[CC-6]
     }
 
-    /// @notice Schedules an LT ramping for any token except underlying
-    /// @param token Token to ramp LT for
-    /// @param liquidationThresholdFinal Liquidation threshold after ramping
-    /// @param rampDuration Duration of ramping
+    /// @notice Schedules token's liquidation threshold ramping
+    /// @param token Token to ramp the LT for
+    /// @param liquidationThresholdFinal Final LT after ramping in bps
+    /// @param rampStart Timestamp to start the ramping at
+    /// @param rampDuration Ramping duration
+    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `token` is not recognized as collateral in the credit manager
+    /// @dev Reverts if `liquidationThresholdFinal` is greater than underlying's LT
     function rampLiquidationThreshold(
         address token,
         uint16 liquidationThresholdFinal,
@@ -270,25 +254,19 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         external
         override
         nonUnderlyingTokenOnly(token)
-        controllerOnly // I: [CC-2B]
+        controllerOnly // I:[CC-2B]
     {
         (, uint16 ltUnderlying) =
             CreditManagerV3(creditManager).collateralTokenByMask({tokenMask: UNDERLYING_TOKEN_MASK});
-        // Sanity check for the liquidation threshold. The LT should be less than underlying
+
         if (liquidationThresholdFinal > ltUnderlying) {
             revert IncorrectLiquidationThresholdException(); // I:[CC-30]
         }
 
-        // In case that (for some reason) the function is executed later than
-        // the start of the ramp, we start the ramp from the current moment
-        // to prevent discontinueous jumps in token's LT
+        // if function is executed later than `rampStart`, start from `block.timestamp` to avoid LT jumps
         rampStart = block.timestamp > rampStart ? uint40(block.timestamp) : rampStart; // I:[CC-30]
 
         uint16 currentLT = CreditManagerV3(creditManager).liquidationThresholds({token: token}); // I:[CC-30]
-
-        // CollateralTokenData in CreditManager stores 4 values: ltInitial, ltFinal, rampStart and rampDuration
-        // The actual LT changes linearly between ltInitial and ltFinal over rampDuration;
-        // E.g., it is ltInitial when block.timestamp == rampStart and ltFinal when block.timestamp == rampStart + rampDuration
         CreditManagerV3(creditManager).setCollateralTokenData({
             token: token,
             ltInitial: currentLT,
@@ -306,34 +284,10 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         }); // I:[CC-30]
     }
 
-    /// @notice Allow a known collateral token if it was forbidden before.
-    /// @param token Address of collateral token
-    function allowToken(address token)
-        external
-        override
-        nonZeroAddress(token)
-        nonUnderlyingTokenOnly(token)
-        configuratorOnly // I:[CC-2]
-    {
-        CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
-
-        // Gets token masks. Reverts if the token was not added as collateral
-        uint256 tokenMask = _getTokenMaskOrRevert({token: token}); // I:[CC-7]
-
-        // If the token was forbidden before, flips the corresponding bit in the mask,
-        // otherwise no actions done.
-        // Skipping case: I:[CC-8]
-        if (cf.forbiddenTokenMask() & tokenMask == 0) return;
-
-        cf.setTokenAllowance({token: token, allowance: AllowanceAction.ALLOW}); // I:[CC-8]
-        emit AllowToken({token: token}); // I:[CC-8]
-    }
-
-    /// @notice Forbids a collateral token.
-    /// Forbidden tokens are counted as collateral during health checks, however, they cannot be enabled
-    /// or received as a result of adapter operation anymore. This means that a token can never be
-    /// acquired through adapter operations after being forbidden.
-    /// @param token Address of collateral token to forbid
+    /// @notice Forbids collateral token in the credit facade
+    /// @param token Token to forbid
+    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `token` is not recognized as collateral in the credit manager
     function forbidToken(address token)
         external
         override
@@ -344,29 +298,45 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _forbidToken({_creditFacade: creditFacade(), token: token});
     }
 
-    /// @dev IMPLEMENTATION: forbidToken
+    /// @dev `forbidToken` implementation
     function _forbidToken(address _creditFacade, address token) internal {
         CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
 
-        // Gets token masks. Reverts if the token was not added as collateral
         uint256 tokenMask = _getTokenMaskOrRevert({token: token}); // I:[CC-9]
-
-        // If the token was not forbidden before, flips the corresponding bit in the mask,
-        // otherwise no actions done.
-        // Skipping case: I:[CC-9]
-        if (cf.forbiddenTokenMask() & tokenMask != 0) return;
+        if (cf.forbiddenTokenMask() & tokenMask != 0) return; // I:[CC-9]
 
         cf.setTokenAllowance({token: token, allowance: AllowanceAction.FORBID}); // I:[CC-9]
         emit ForbidToken({token: token}); // I:[CC-9]
     }
 
-    /// @notice Marks the token as limited, which enables quota logic and additional interest for it
-    /// @param token Token to make limited
-    /// @dev This action is irreversible!
+    /// @notice Allows a previously forbidden collateral token in the credit facade
+    /// @param token Token to allow
+    /// @dev Reverts if `token` is underlying
+    /// @dev Reverts if `token` is not recognized as collateral in the credit manager
+    function allowToken(address token)
+        external
+        override
+        nonZeroAddress(token)
+        nonUnderlyingTokenOnly(token)
+        configuratorOnly // I:[CC-2]
+    {
+        CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
+
+        uint256 tokenMask = _getTokenMaskOrRevert({token: token}); // I:[CC-7]
+        if (cf.forbiddenTokenMask() & tokenMask == 0) return; // I:[CC-8]
+
+        cf.setTokenAllowance({token: token, allowance: AllowanceAction.ALLOW}); // I:[CC-8]
+        emit AllowToken({token: token}); // I:[CC-8]
+    }
+
+    /// @notice Makes token quoted
+    /// @param token Token to make quoted
+    /// @dev Reverts if `token` is not quoted in the quota keeper
+    /// @dev Reverts if `token` is not recognized as collateral in the credit manager
     function makeTokenQuoted(address token)
         external
         override
-        configuratorOnly // I: [CC-2]
+        configuratorOnly // I:[CC-2]
     {
         if (!_isQuotedToken(token)) {
             revert TokenIsNotQuotedException();
@@ -374,42 +344,31 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _makeTokenQuoted(token);
     }
 
-    /// @dev IMPLEMENTATION: _makeTokenQuoted
+    /// @dev `makeTokenQuoted` implementation
     function _makeTokenQuoted(address token) internal nonUnderlyingTokenOnly(token) {
-        // Gets token masks. Reverts if the token was not added as collateral
         uint256 tokenMask = _getTokenMaskOrRevert({token: token});
-
-        // Gets current limited mask
         uint256 quotedTokensMask = CreditManagerV3(creditManager).quotedTokensMask();
-
-        // If the token was not limited before, flips the corresponding bit in the mask,
-        // otherwise no actions done.
         if (quotedTokensMask & tokenMask != 0) return;
 
         CreditManagerV3(creditManager).setQuotedMask(quotedTokensMask.enable(tokenMask));
         emit QuoteToken(token);
     }
 
-    /// @dev Checks whether the quota keeper (if it is set) has a token registered as quoted
-    function _isQuotedToken(address token) internal view returns (bool) {
-        address quotaKeeper = CreditManagerV3(creditManager).poolQuotaKeeper();
-        if (quotaKeeper == address(0)) return false;
-        return IPoolQuotaKeeperV3(quotaKeeper).isQuotedToken(token);
+    // -------- //
+    // ADAPTERS //
+    // -------- //
+
+    /// @notice Returns all allowed adapters
+    function allowedAdapters() external view override returns (address[] memory) {
+        return allowedAdaptersSet.values();
     }
 
-    /// @dev Helper to get token mask
-    function _getTokenMaskOrRevert(address token) internal view returns (uint256 tokenMask) {
-        return CreditManagerV3(creditManager).getTokenMaskOrRevert(token); // I:[CC-7]
-    }
-
-    //
-    // CONFIGURATION: CONTRACTS & ADAPTERS MANAGEMENT
-    //
-
-    /// @notice Adds pair [contract <-> adapter] to the list of allowed contracts
-    /// or updates adapter address if a contract already has a connected adapter
-    /// @dev The target contract is retrieved from the adapter
-    /// @param adapter Adapter address
+    /// @notice Allows a new adapter in the credit manager
+    /// @notice If adapter's target contract already has an adapter in the credit manager, it is removed
+    /// @param adapter Adapter to allow
+    /// @dev Reverts if `adapter` is incompatible with the credit manager
+    /// @dev Reverts if `adapter`'s target contract is not a contract
+    /// @dev Reverts if `adapter` or its target contract is credit manager or credit facade
     function allowAdapter(address adapter)
         external
         override
@@ -421,34 +380,28 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
             revert AddressIsNotContractException(targetContract); // I:[CC-10A]
         }
 
-        // Additional check that adapter or targetContract is not Credit Manager or Credit Facade.
-        // Credit Manager and Credit Facade are security-critical, and calling them through adapters
-        // can have unforeseen consequences.
         if (
             targetContract == creditManager || targetContract == creditFacade() || adapter == creditManager
                 || adapter == creditFacade()
         ) revert TargetContractNotAllowedException(); // I:[CC-10C]
 
-        // If there is an existing adapter for the target contract, it has to be removed
         address currentAdapter = CreditManagerV3(creditManager).contractToAdapter(targetContract);
         if (currentAdapter != address(0)) {
             CreditManagerV3(creditManager).setContractAllowance({adapter: currentAdapter, targetContract: address(0)}); // I:[CC-12]
             allowedAdaptersSet.remove(currentAdapter); // I:[CC-12]
         }
 
-        // Sets a link between adapter and targetContract in creditFacade and creditManager
         CreditManagerV3(creditManager).setContractAllowance({adapter: adapter, targetContract: targetContract}); // I:[CC-11]
 
-        // adds contract to the list of allowed contracts
         allowedAdaptersSet.add(adapter); // I:[CC-11]
 
         emit AllowAdapter({targetContract: targetContract, adapter: adapter}); // I:[CC-11]
     }
 
-    /// @notice Forbids an adapter as a target for calls from Credit Accounts
-    /// Internally, mappings that determine the adapter <> targetContract link
-    /// Are reset to zero addresses
-    /// @param adapter Address of an adapter to be forbidden
+    /// @notice Forbids both adapter and its target contract in the credit manager
+    /// @param adapter Adapter to forbid
+    /// @dev Reverts if `adapter` is incompatible with the credit manager
+    /// @dev Reverts if `adapter` is not registered in the credit manager
     function forbidAdapter(address adapter)
         external
         override
@@ -456,27 +409,21 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         controllerOnly // I:[CC-2B]
     {
         address targetContract = _getTargetContractOrRevert({adapter: adapter});
-
-        // Checks that adapter in the CM is the same as the passed adapter
         if (CreditManagerV3(creditManager).adapterToContract(adapter) == address(0)) {
             revert AdapterIsNotRegisteredException(); // I:[CC-13]
         }
 
-        // Sets both contractToAdapter[targetContract] and adapterToContract[adapter]
-        // To address(0), which would make Credit Manager revert on attempts to
-        // call the respective targetContract using the adapter
         CreditManagerV3(creditManager).setContractAllowance({adapter: adapter, targetContract: address(0)}); // I:[CC-14]
         CreditManagerV3(creditManager).setContractAllowance({adapter: address(0), targetContract: targetContract}); // I:[CC-14]
 
-        // removes contract from the list of allowed contracts
         allowedAdaptersSet.remove(adapter); // I:[CC-14]
 
         emit ForbidAdapter({targetContract: targetContract, adapter: adapter}); // I:[CC-14]
     }
 
-    /// @dev Checks adapter compatibility and retrieves the target contract with proper error handling
+    /// @dev Checks that adapter is compatible with credit manager and returns its target contract
     function _getTargetContractOrRevert(address adapter) internal view returns (address targetContract) {
-        _revertIfContractIncompatible(adapter); // I: [CC-10, CC-10B]
+        _revertIfContractIncompatible(adapter); // I:[CC-10,10B]
 
         try IAdapter(adapter).targetContract() returns (address tc) {
             targetContract = tc;
@@ -487,50 +434,39 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         if (targetContract == address(0)) revert TargetContractNotAllowedException();
     }
 
-    //
-    // CREDIT MANAGER MGMT
-    //
+    // -------------- //
+    // CREDIT MANAGER //
+    // -------------- //
 
-    /// @notice Sets the minimal borrowed amount limit in Credit Facade
-    /// @param minDebt Minimum borrowed amount
-    function setMinDebtLimit(uint128 minDebt) external override controllerOnly {
-        address cf = creditFacade();
-        (, uint128 currentMaxDebt) = CreditFacadeV3(cf).debtLimits();
-        _setLimits(cf, minDebt, currentMaxDebt);
+    /// @notice Sets the maximum number of tokens enabled as collateral on a credit account
+    /// @param newMaxEnabledTokens New maximum number of enabled tokens
+    /// @dev Reverts if `newMaxEnabledTokens` is zero
+    function setMaxEnabledTokens(uint8 newMaxEnabledTokens)
+        external
+        override
+        configuratorOnly // I:[CC-2]
+    {
+        CreditManagerV3 cm = CreditManagerV3(creditManager);
+
+        if (newMaxEnabledTokens == 0) revert IncorrectParameterException(); // I:[CC-26]
+
+        if (newMaxEnabledTokens == cm.maxEnabledTokens()) return;
+
+        cm.setMaxEnabledTokens(newMaxEnabledTokens); // I:[CC-26]
+        emit SetMaxEnabledTokens(newMaxEnabledTokens); // I:[CC-26]
     }
 
-    /// @notice Sets the maximal borrowed amount limit in Credit Facade
-    /// @param maxDebt Maximum borrowed amount
-    function setMaxDebtLimit(uint128 maxDebt) external override controllerOnly {
-        address cf = creditFacade();
-        (uint128 currentMinDebt,) = CreditFacadeV3(cf).debtLimits();
-        _setLimits(cf, currentMinDebt, maxDebt);
-    }
-
-    /// @dev IMPLEMENTATION: setLimits
-    function _setLimits(address _creditFacade, uint128 minDebt, uint128 maxDebt) internal {
-        // Performs sanity checks on limits:
-        // maxDebt must not be less than minDebt
-        if (minDebt > maxDebt) {
-            revert IncorrectLimitsException();
-        } // I:[CC-15]
-
-        CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
-
-        // Checks that at least one limit is changed to avoid redundant events
-        (uint128 currentMinDebt, uint128 currentMaxDebt) = cf.debtLimits();
-        if (currentMinDebt == minDebt && currentMaxDebt == maxDebt) return;
-
-        cf.setDebtLimits(minDebt, maxDebt, cf.maxDebtPerBlockMultiplier()); // I:[CC-16]
-        emit SetBorrowingLimits(minDebt, maxDebt); // I:[CC-1A,19]
-    }
-
-    /// @notice Sets fees for creditManager
-    /// @param feeInterest Percent which protocol charges additionally for interest rate
-    /// @param feeLiquidation The fee that is paid to the pool from liquidation
-    /// @param liquidationPremium Discount for totalValue which is given to liquidator
-    /// @param feeLiquidationExpired The fee that is paid to the pool from liquidation when liquidating an expired account
-    /// @param liquidationPremiumExpired Discount for totalValue which is given to liquidator when liquidating an expired account
+    /// @notice Sets new fees params in the credit manager (all fields in bps)
+    /// @notice Sets underlying token's liquidation threshold to 1 - liquidation fee - liquidation premium and
+    ///         upper-bounds all other tokens' LTs with this number, which interrupts ongoing LT rampings
+    /// @param feeInterest Percentage of accrued interest taken by the protocol as profit
+    /// @param feeLiquidation Percentage of liquidated account value taken by the protocol as profit
+    /// @param liquidationPremium Percentage of liquidated account value that can be taken by liquidator
+    /// @param feeLiquidationExpired Percentage of liquidated expired account value taken by the protocol as profit
+    /// @param liquidationPremiumExpired Percentage of liquidated expired account value that can be taken by liquidator
+    /// @dev Reverts if `feeInterest` is above 100%
+    /// @dev Reverts if `liquidationPremium + feeLiquidation` is above 100%
+    /// @dev Reverts if `liquidationPremiumExpired + feeLiquidationExpired` is above 100%
     function setFees(
         uint16 feeInterest,
         uint16 feeLiquidation,
@@ -542,7 +478,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         override
         configuratorOnly // I:[CC-2]
     {
-        // Checks that feeInterest and (liquidationPremium + feeLiquidation) are in range [0..10000]
         if (
             feeInterest >= PERCENTAGE_FACTOR || (liquidationPremium + feeLiquidation) >= PERCENTAGE_FACTOR
                 || (liquidationPremiumExpired + feeLiquidationExpired) >= PERCENTAGE_FACTOR
@@ -557,8 +492,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         });
     }
 
-    /// @dev IMPLEMENTATION: setFees
-    ///      Does sanity checks on fee params and sets them in CreditManagerV3
+    /// @dev `setFees` implementation
     function _setFees(
         uint16 feeInterest,
         uint16 feeLiquidation,
@@ -566,7 +500,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         uint16 feeLiquidationExpired,
         uint16 liquidationDiscountExpired
     ) internal {
-        // Computes the underlying LT and updates it if required
         uint16 newLTUnderlying = uint16(liquidationDiscount - feeLiquidation); // I:[CC-18]
         (, uint16 ltUnderlying) =
             CreditManagerV3(creditManager).collateralTokenByMask({tokenMask: UNDERLYING_TOKEN_MASK});
@@ -584,7 +517,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
             uint16 _liquidationDiscountExpiredCurrent
         ) = CreditManagerV3(creditManager).fees();
 
-        // Checks that at least one parameter is changed
         if (
             (feeInterest == _feeInterestCurrent) && (feeLiquidation == _feeLiquidationCurrent)
                 && (liquidationDiscount == _liquidationDiscountCurrent)
@@ -592,7 +524,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
                 && (liquidationDiscountExpired == _liquidationDiscountExpiredCurrent)
         ) return;
 
-        // updates params in creditManager
         CreditManagerV3(creditManager).setFees({
             _feeInterest: feeInterest,
             _feeLiquidation: feeLiquidation,
@@ -610,8 +541,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         }); // I:[CC-1A,19]
     }
 
-    /// @dev Updates Liquidation threshold for the underlying asset
-    /// @param ltUnderlying New LT for the underlying
+    /// @dev Updates underlying token's liquidation threshold
     function _updateUnderlyingLT(uint16 ltUnderlying) internal {
         CreditManagerV3(creditManager).setCollateralTokenData({
             token: underlying,
@@ -621,9 +551,6 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
             rampDuration: 0
         }); // I:[CC-25]
 
-        // An LT of an ordinary collateral token cannot be larger than the LT of underlying
-        // As such, all LTs need to be checked and reduced if needed
-        // NB: This action will interrupt all ongoing LT ramps
         uint256 len = CreditManagerV3(creditManager).collateralTokensCount();
         unchecked {
             for (uint256 i = 1; i < len; ++i) {
@@ -635,77 +562,89 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         }
     }
 
-    //
-    // CONTRACT UPGRADES
-    //
+    // -------- //
+    // UPGRADES //
+    // -------- //
 
-    /// @notice Upgrades the price oracle in the Credit Manager, taking the address from the address provider
-    function setPriceOracle(uint256 _version)
+    /// @notice Sets the new price oracle contract in the credit manager
+    /// @param newVersion Version of the new price oracle to take from the address provider
+    /// @dev Reverts if price oracle of given version is not found in the address provider
+    function setPriceOracle(uint256 newVersion)
         external
         override
         configuratorOnly // I:[CC-2]
     {
-        address priceOracle = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_PRICE_ORACLE, _version); // I:[CC-21]
+        address priceOracle = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_PRICE_ORACLE, newVersion); // I:[CC-21]
 
-        // Checks that the price oracle is actually new to avoid emitting redundant events
         if (priceOracle == CreditManagerV3(creditManager).priceOracle()) return;
 
         CreditManagerV3(creditManager).setPriceOracle(priceOracle); // I:[CC-21]
         emit SetPriceOracle(priceOracle); // I:[CC-21]
     }
 
-    /// @notice Upgrades the Credit Facade corresponding to the Credit Manager
-    /// @param _creditFacade address of the new Credit Facade
-    /// @param migrateParams Whether the previous Credit Facade's parameters need to be copied
-    function setCreditFacade(address _creditFacade, bool migrateParams)
+    /// @notice Sets the new bot list contract in the credit facade
+    /// @param newVersion Version of the new bot list to take from the address provider
+    /// @dev Reverts if bot list of given version is not found in the address provider
+    function setBotList(uint256 newVersion)
         external
         override
         configuratorOnly // I:[CC-2]
     {
-        // Retrieves all parameters in case they need to be migrated
-        CreditFacadeV3 prevCreditFacade = CreditFacadeV3(creditFacade());
-
-        // Checks that the Credit Facade is actually changed, to avoid any redundant actions and events
-        if (_creditFacade == address(prevCreditFacade)) return;
-
-        // Sanity checks that the address is a contract and has correct Credit Manager
-        _revertIfContractIncompatible(_creditFacade); // I:[CC-20]
-
-        // Sets Credit Facade to the new address
-        CreditManagerV3(creditManager).setCreditFacade(_creditFacade); // I:[CC-22]
-
-        if (migrateParams) {
-            // Copies all limits and restrictions on borrowing
-            _setMaxDebtPerBlockMultiplier(_creditFacade, prevCreditFacade.maxDebtPerBlockMultiplier()); // I:[CC-22]
-
-            // Copy debt limits
-            (uint128 minDebt, uint128 maxDebt) = prevCreditFacade.debtLimits();
-            _setLimits({_creditFacade: _creditFacade, minDebt: minDebt, maxDebt: maxDebt}); // I:[CC-22]
-
-            // Copy max cumulative loss params
-            (, uint128 maxCumulativeLoss) = prevCreditFacade.lossParams();
-            _setMaxCumulativeLoss(_creditFacade, maxCumulativeLoss); // I: [CC-22]
-
-            // Migrates array-based parameters
-            _migrateEmergencyLiquidators(_creditFacade); // I:[CC-22С]
-
-            // Copy forbidden token mask
-            _migrateForbiddenTokens(_creditFacade, prevCreditFacade.forbiddenTokenMask()); // I:[CC-22С]
-
-            // Copies the expiration date if the contract is expirable
-            if (prevCreditFacade.expirable()) _setExpirationDate(_creditFacade, prevCreditFacade.expirationDate()); // I:[CC-22]
-
-            address botList = prevCreditFacade.botList();
-            if (botList != address(0)) _setBotList(_creditFacade, botList); // I:[CC-22A]
-        } else {
-            _clearArrayCreditFacadeParams(); // I:[CC-22С]
-        }
-
-        emit SetCreditFacade(_creditFacade); // I:[CC-22]
+        address botList = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_BOT_LIST, newVersion); // I:[CC-33]
+        _setBotList(creditFacade(), botList); // I:[CC-33]
     }
 
-    /// @dev Internal function to migrate emergency liquidators when
-    ///      updating the Credit Facade
+    /// @dev `setBotList` implementation
+    function _setBotList(address _creditFacade, address botList) internal {
+        CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
+        if (botList == cf.botList()) return;
+        cf.setBotList(botList); // I:[CC-33]
+        emit SetBotList(botList); // I:[CC-33]
+    }
+
+    /// @notice Upgrades a facade connected to the credit manager
+    /// @param newCreditFacade New credit facade
+    /// @param migrateParams Whether to migrate old credit facade params
+    /// @dev Reverts if `newCreditFacade` is incompatible with credit manager
+    /// @dev If `migrateParams` is true, reverts if old facade is expirable and the new one is not
+    function setCreditFacade(address newCreditFacade, bool migrateParams)
+        external
+        override
+        configuratorOnly // I:[CC-2]
+    {
+        CreditFacadeV3 prevCreditFacade = CreditFacadeV3(creditFacade());
+        if (newCreditFacade == address(prevCreditFacade)) return;
+
+        _revertIfContractIncompatible(newCreditFacade); // I:[CC-20]
+
+        CreditManagerV3(creditManager).setCreditFacade(newCreditFacade); // I:[CC-22]
+
+        if (migrateParams) {
+            _setMaxDebtPerBlockMultiplier(newCreditFacade, prevCreditFacade.maxDebtPerBlockMultiplier()); // I:[CC-22]
+
+            (uint128 minDebt, uint128 maxDebt) = prevCreditFacade.debtLimits();
+            _setLimits({_creditFacade: newCreditFacade, minDebt: minDebt, maxDebt: maxDebt}); // I:[CC-22]
+
+            (, uint128 maxCumulativeLoss) = prevCreditFacade.lossParams();
+            _setMaxCumulativeLoss(newCreditFacade, maxCumulativeLoss); // [CC-22]
+
+            _migrateEmergencyLiquidators(newCreditFacade); // I:[CC-22С]
+
+            _migrateForbiddenTokens(newCreditFacade, prevCreditFacade.forbiddenTokenMask()); // I:[CC-22С]
+
+            if (prevCreditFacade.expirable()) _setExpirationDate(newCreditFacade, prevCreditFacade.expirationDate()); // I:[CC-22]
+
+            address botList = prevCreditFacade.botList();
+            if (botList != address(0)) _setBotList(newCreditFacade, botList); // I:[CC-22A]
+        } else {
+            // emergency liquidators set must be cleared to keep it consistent between facade and configurator
+            _clearEmergencyLiquidatorsSet(); // I:[CC-22С]
+        }
+
+        emit SetCreditFacade(newCreditFacade); // I:[CC-22]
+    }
+
+    /// @dev Migrate emergency liquidators to the new credit facade
     function _migrateEmergencyLiquidators(address _creditFacade) internal {
         uint256 len = emergencyLiquidatorsSet.length();
         unchecked {
@@ -715,25 +654,21 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         }
     }
 
-    /// @dev Internal function to migrate forbidden tokens when
-    ///      updating the Credit Facade
-    function _migrateForbiddenTokens(address _creditFacade, uint256 forbiddenTokenMask) internal {
+    /// @dev Migrates forbidden tokens to the new credit facade
+    function _migrateForbiddenTokens(address _creditFacade, uint256 forbiddenTokensMask) internal {
         unchecked {
-            for (uint256 mask = 2; mask <= forbiddenTokenMask; mask <<= 1) {
-                if (mask & forbiddenTokenMask != 0) {
-                    address token = CreditManagerV3(creditManager).getTokenByMask(mask);
-                    _forbidToken(_creditFacade, token);
-                }
+            while (forbiddenTokensMask != 0) {
+                uint256 mask = forbiddenTokensMask & uint256(-int256(forbiddenTokensMask));
+                address token = CreditManagerV3(creditManager).getTokenByMask(mask);
+                _forbidToken(_creditFacade, token);
+                forbiddenTokensMask &= forbiddenTokensMask - 1;
             }
         }
     }
 
-    /// @dev Clears array-based parameters in Credit Facade
-    /// @dev Needs to be done on changing a Credit Facade without migrating parameters,
-    ///      in order to keep these parameters consistent between the CC and the CF
-    function _clearArrayCreditFacadeParams() internal {
+    /// @dev Clears emergency liquidators set
+    function _clearEmergencyLiquidatorsSet() internal {
         uint256 len = emergencyLiquidatorsSet.length();
-
         unchecked {
             for (uint256 i; i < len; ++i) {
                 emergencyLiquidatorsSet.remove(emergencyLiquidatorsSet.at(len - i - 1));
@@ -741,85 +676,60 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         }
     }
 
-    /// @notice Upgrades the Credit Configurator for a connected Credit Manager
-    /// @param _creditConfigurator New Credit Configurator's address
-    /// @dev After this function executes, this Credit Configurator no longer
-    ///         has admin access to the Credit Manager
-    function upgradeCreditConfigurator(address _creditConfigurator)
+    /// @notice Upgrades credit manager's configurator contract
+    /// @param newCreditConfigurator New credit configurator
+    /// @dev Reverts if `newCreditConfigurator` is incompatible with credit manager
+    function upgradeCreditConfigurator(address newCreditConfigurator)
         external
         override
         configuratorOnly // I:[CC-2]
     {
-        if (_creditConfigurator == address(this)) return;
+        if (newCreditConfigurator == address(this)) return;
 
-        _revertIfContractIncompatible(_creditConfigurator); // I:[CC-20]
-        CreditManagerV3(creditManager).setCreditConfigurator(_creditConfigurator); // I:[CC-23]
-        emit CreditConfiguratorUpgraded(_creditConfigurator); // I:[CC-23]
+        _revertIfContractIncompatible(newCreditConfigurator); // I:[CC-20]
+        CreditManagerV3(creditManager).setCreditConfigurator(newCreditConfigurator); // I:[CC-23]
+        emit CreditConfiguratorUpgraded(newCreditConfigurator); // I:[CC-23]
     }
 
-    /// @dev Performs sanity checks that the address is a contract compatible with the Credit Manager
-    function _revertIfContractIncompatible(address _contract)
-        internal
-        view
-        nonZeroAddress(_contract) // I:[CC-12,29]
-    {
-        // Checks that the address is a contract
-        if (!_contract.isContract()) {
-            revert AddressIsNotContractException(_contract);
-        } // I:[CC-12A,29]
+    // ------------- //
+    // CREDIT FACADE //
+    // ------------- //
 
-        // Checks that the contract has a creditManager() function, which returns a correct value
-        try CreditFacadeV3(_contract).creditManager() returns (address cm) {
-            if (cm != creditManager) revert IncompatibleContractException(); // I:[CC-12B,29]
-        } catch {
-            revert IncompatibleContractException(); // I:[CC-12B,29]
+    /// @notice Sets the new min debt limit in the credit facade
+    /// @param minDebt New minimum debt per credit account
+    /// @dev Reverts if `minDebt` is greater than the current max debt
+    function setMinDebtLimit(uint128 minDebt) external override controllerOnly {
+        address cf = creditFacade();
+        (, uint128 currentMaxDebt) = CreditFacadeV3(cf).debtLimits();
+        _setLimits(cf, minDebt, currentMaxDebt);
+    }
+
+    /// @notice Sets the new max debt limit in the credit facade
+    /// @param maxDebt New maximum debt per credit account
+    /// @dev Reverts if `maxDebt` is less than the current min debt
+    function setMaxDebtLimit(uint128 maxDebt) external override controllerOnly {
+        address cf = creditFacade();
+        (uint128 currentMinDebt,) = CreditFacadeV3(cf).debtLimits();
+        _setLimits(cf, currentMinDebt, maxDebt);
+    }
+
+    /// @dev `set{Min|Max}DebtLimit` implementation
+    function _setLimits(address _creditFacade, uint128 minDebt, uint128 maxDebt) internal {
+        if (minDebt > maxDebt) {
+            revert IncorrectLimitsException(); // I:[CC-15]
         }
-    }
 
-    /// @notice Disables borrowing in Credit Facade (and, consequently, the Credit Manager)
-    function forbidBorrowing()
-        external
-        override
-        pausableAdminsOnly // I: [CC-2A]
-    {
-        /// This is done by setting the max debt per block multiplier to 0, which prevents all new borrowing
-        _setMaxDebtPerBlockMultiplier(creditFacade(), 0); // I: [CC-24]
-    }
-
-    /// @notice Sets the max cumulative loss, which is a threshold of total loss that triggers a system pause
-    function setMaxCumulativeLoss(uint128 _maxCumulativeLoss)
-        external
-        override
-        configuratorOnly // I:[CC-02]
-    {
-        _setMaxCumulativeLoss(creditFacade(), _maxCumulativeLoss); // I: [CC-31]
-    }
-
-    /// @dev IMPLEMENTATION: setMaxCumulativeLoss
-    function _setMaxCumulativeLoss(address _creditFacade, uint128 _maxCumulativeLoss) internal {
         CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
 
-        (, uint128 maxCumulativeLossCurrent) = cf.lossParams(); // I: [CC-31]
-        if (_maxCumulativeLoss == maxCumulativeLossCurrent) return;
+        (uint128 currentMinDebt, uint128 currentMaxDebt) = cf.debtLimits();
+        if (currentMinDebt == minDebt && currentMaxDebt == maxDebt) return;
 
-        cf.setCumulativeLossParams(_maxCumulativeLoss, false); // I: [CC-31]
-        emit SetMaxCumulativeLoss(_maxCumulativeLoss); // I: [CC-31]
+        cf.setDebtLimits(minDebt, maxDebt, cf.maxDebtPerBlockMultiplier()); // I:[CC-16]
+        emit SetBorrowingLimits(minDebt, maxDebt); // I:[CC-1A,19]
     }
 
-    /// @notice Resets the current cumulative loss
-    function resetCumulativeLoss()
-        external
-        override
-        configuratorOnly // I:[CC-02]
-    {
-        CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
-        (, uint128 maxCumulativeLossCurrent) = cf.lossParams(); // I: [CC-32]
-        cf.setCumulativeLossParams(maxCumulativeLossCurrent, true); // I: [CC-32]
-        emit ResetCumulativeLoss(); // I: [CC-32]
-    }
-
-    /// @notice Sets the maximal borrowed amount per block
-    /// @param newMaxDebtLimitPerBlockMultiplier The new max borrowed amount per block
+    /// @notice Sets the new max debt per block multiplier in the credit facade
+    /// @param newMaxDebtLimitPerBlockMultiplier The new max debt per block multiplier
     function setMaxDebtPerBlockMultiplier(uint8 newMaxDebtLimitPerBlockMultiplier)
         external
         override
@@ -828,11 +738,19 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _setMaxDebtPerBlockMultiplier(creditFacade(), newMaxDebtLimitPerBlockMultiplier); // I:[CC-24]
     }
 
-    /// @dev IMPLEMENTATION: _setMaxDebtPerBlockMultiplier
+    /// @notice Disables borrowing in the credit facade by setting max debt per block multiplier to zero
+    function forbidBorrowing()
+        external
+        override
+        pausableAdminsOnly // I:[CC-2A]
+    {
+        _setMaxDebtPerBlockMultiplier(creditFacade(), 0); // I:[CC-24]
+    }
+
+    /// @dev `setMaxDebtPerBlockMultiplier` implementation
     function _setMaxDebtPerBlockMultiplier(address _creditFacade, uint8 newMaxDebtLimitPerBlockMultiplier) internal {
         CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
 
-        // Checks that the limit is actually changed to avoid redundant events
         if (newMaxDebtLimitPerBlockMultiplier == cf.maxDebtPerBlockMultiplier()) return;
 
         (uint128 minDebt, uint128 maxDebt) = cf.debtLimits();
@@ -840,9 +758,44 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         emit SetMaxDebtPerBlockMultiplier(newMaxDebtLimitPerBlockMultiplier); // I:[CC-1A,24]
     }
 
-    /// @notice Sets expiration date in a CreditFacadeV3 connected
-    /// To a CreditManagerV3 with an expirable pool
-    /// @param newExpirationDate The timestamp of the next expiration
+    /// @notice Sets the new maximum cumulative loss from bad debt liquidations
+    /// @param newMaxCumulativeLoss New max cumulative lossd
+    function setMaxCumulativeLoss(uint128 newMaxCumulativeLoss)
+        external
+        override
+        configuratorOnly // I:[CC-2]
+    {
+        _setMaxCumulativeLoss(creditFacade(), newMaxCumulativeLoss); // I:[CC-31]
+    }
+
+    /// @dev `setMaxCumulativeLoss` implementation
+    function _setMaxCumulativeLoss(address _creditFacade, uint128 _maxCumulativeLoss) internal {
+        CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
+
+        (, uint128 maxCumulativeLossCurrent) = cf.lossParams(); // I:[CC-31]
+        if (_maxCumulativeLoss == maxCumulativeLossCurrent) return;
+
+        cf.setCumulativeLossParams(_maxCumulativeLoss, false); // I:[CC-31]
+        emit SetMaxCumulativeLoss(_maxCumulativeLoss); // I:[CC-31]
+    }
+
+    /// @notice Resets the current cumulative loss from bad debt liquidations to zero
+    function resetCumulativeLoss()
+        external
+        override
+        configuratorOnly // I:[CC-2]
+    {
+        CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
+        (, uint128 maxCumulativeLossCurrent) = cf.lossParams(); // I:[CC-32]
+        cf.setCumulativeLossParams(maxCumulativeLossCurrent, true); // I:[CC-32]
+        emit ResetCumulativeLoss(); // I:[CC-32]
+    }
+
+    /// @notice Sets a new credit facade expiration timestamp
+    /// @param newExpirationDate New expiration timestamp
+    /// @dev Reverts if `newExpirationDate` is in the past
+    /// @dev Reverts if `newExpirationDate` is older than the current expiration date
+    /// @dev Reverts if credit facade is not expirable
     function setExpirationDate(uint40 newExpirationDate)
         external
         override
@@ -851,13 +804,10 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _setExpirationDate(creditFacade(), newExpirationDate); // I:[CC-25]
     }
 
-    /// @dev IMPLEMENTATION: setExpirationDate
+    /// @dev `setExpirationDate` implementation
     function _setExpirationDate(address _creditFacade, uint40 newExpirationDate) internal {
         CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
 
-        // Sanity checks on the new expiration date
-        // The new expiration date must be later than the previous one
-        // The new expiration date cannot be earlier than now
         if (block.timestamp > newExpirationDate || cf.expirationDate() >= newExpirationDate) {
             revert IncorrectExpirationDateException(); // I:[CC-25]
         }
@@ -866,54 +816,13 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         emit SetExpirationDate(newExpirationDate); // I:[CC-25]
     }
 
-    /// @notice Sets the maximal amount of enabled tokens per Credit Account
-    /// @param maxEnabledTokens The new maximal number of enabled tokens
-    /// @dev A large number of enabled collateral tokens on a Credit Account
-    /// can make liquidations and health checks prohibitively expensive in terms of gas,
-    /// hence the number is limited
-    function setMaxEnabledTokens(uint8 maxEnabledTokens)
-        external
-        override
-        configuratorOnly // I:[CC-2]
-    {
-        CreditManagerV3 cm = CreditManagerV3(creditManager);
-
-        if (maxEnabledTokens == 0) revert IncorrectParameterException(); // I:[CC-26]
-
-        // Checks that value is actually changed to avoid redundant events
-        if (maxEnabledTokens == cm.maxEnabledTokens()) return;
-
-        cm.setMaxEnabledTokens(maxEnabledTokens); // I:[CC-26]
-        emit SetMaxEnabledTokens(maxEnabledTokens); // I:[CC-26]
-    }
-
-    /// @notice Sets the bot list contract
-    /// @param _version The version of the new bot list contract
-    ///                The contract address is retrieved from addressProvider
-    /// @notice The bot list determines the permissions for actions
-    ///         that bots can perform on Credit Accounts
-    function setBotList(uint256 _version)
-        external
-        override
-        configuratorOnly // I: [CC-2]
-    {
-        address botList = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_BOT_LIST, _version); // I: [CC-33]
-        _setBotList(creditFacade(), botList); // I: [CC-33]
-    }
-
-    /// @dev IMPLEMENTATION: setBotList
-    function _setBotList(address _creditFacade, address botList) internal {
-        CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
-        if (botList == cf.botList()) return;
-        cf.setBotList(botList); // I: [CC-33]
-        emit SetBotList(botList); // I: [CC-33]
+    /// @notice Returns all emergency liquidators
+    function emergencyLiquidators() external view override returns (address[] memory) {
+        return emergencyLiquidatorsSet.values();
     }
 
     /// @notice Adds an address to the list of emergency liquidators
-    /// @param liquidator The address to add to the list
-    /// @dev Emergency liquidators are trusted addresses
-    /// that are able to liquidate positions while the contracts are paused,
-    /// e.g. when there is a risk of bad debt while an exploit is being patched.
+    /// @param liquidator Address to add to the list
     function addEmergencyLiquidator(address liquidator)
         external
         override
@@ -922,15 +831,12 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
         _addEmergencyLiquidator(creditFacade(), liquidator); // I:[CC-27]
     }
 
-    /// @dev IMPLEMENTATION: addEmergencyLiquidator
+    /// @dev `addEmergencyLiquidator` implementation
     function _addEmergencyLiquidator(address _creditFacade, address liquidator) internal {
         CreditFacadeV3 cf = CreditFacadeV3(_creditFacade);
 
-        // The emergency liquidator is added here, in case
-        // it somehow exists in Credit Facade, but not in the set
         emergencyLiquidatorsSet.add(liquidator); // I:[CC-27]
 
-        // Checks that the address is not already in the list to avoid redundant events
         if (cf.canLiquidateWhilePaused(liquidator)) return;
 
         cf.setEmergencyLiquidator(liquidator, AllowanceAction.ALLOW); // I:[CC-27]
@@ -938,7 +844,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
     }
 
     /// @notice Removes an address from the list of emergency liquidators
-    /// @param liquidator The address to remove from the list
+    /// @param liquidator Address to remove from the list
     function removeEmergencyLiquidator(address liquidator)
         external
         override
@@ -946,33 +852,49 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
     {
         CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
 
-        // The emergency liquidator is removed here, in case
-        // it somehow exists in the set, but not in Credit Facade
         emergencyLiquidatorsSet.remove(liquidator); // I:[CC-28]
 
-        // Checks that the address is in the list to avoid redundant events
         if (!cf.canLiquidateWhilePaused(liquidator)) return;
 
         cf.setEmergencyLiquidator(liquidator, AllowanceAction.FORBID); // I:[CC-28]
         emit RemoveEmergencyLiquidator(liquidator); // I:[CC-28]
     }
 
-    //
-    // GETTERS
-    //
+    // --------- //
+    // INTERNALS //
+    // --------- //
 
-    /// @notice Returns all allowed adapters
-    function allowedAdapters() external view override returns (address[] memory) {
-        return allowedAdaptersSet.values();
+    /// @dev Checks whether the quota keeper (if it is set) has a token registered as quoted
+    function _isQuotedToken(address token) internal view returns (bool) {
+        address quotaKeeper = CreditManagerV3(creditManager).poolQuotaKeeper();
+        if (quotaKeeper == address(0)) return false;
+        return IPoolQuotaKeeperV3(quotaKeeper).isQuotedToken(token);
     }
 
-    /// @notice Returns all emergency liquidators
-    function emergencyLiquidators() external view override returns (address[] memory) {
-        return emergencyLiquidatorsSet.values();
+    /// @dev Internal wrapper for `creditManager.getTokenMaskOrRevert` call to reduce contract size
+    function _getTokenMaskOrRevert(address token) internal view returns (uint256 tokenMask) {
+        return CreditManagerV3(creditManager).getTokenMaskOrRevert(token); // I:[CC-7]
     }
 
-    /// @notice Returns the Credit Facade currently connected to the Credit Manager
-    function creditFacade() public view override returns (address) {
-        return CreditManagerV3(creditManager).creditFacade();
+    /// @dev Ensures that contract is compatible with credit manager
+    function _revertIfContractIncompatible(address _contract)
+        internal
+        view
+        nonZeroAddress(_contract) // I:[CC-12,29]
+    {
+        if (!_contract.isContract()) {
+            revert AddressIsNotContractException(_contract); // I:[CC-12A,29]
+        }
+
+        try CreditFacadeV3(_contract).creditManager() returns (address cm) {
+            if (cm != creditManager) revert IncompatibleContractException(); // I:[CC-12B,29]
+        } catch {
+            revert IncompatibleContractException(); // I:[CC-12B,29]
+        }
+    }
+
+    /// @dev Reverts if `token` is underlying
+    function _revertIfUnderlyingToken(address token) internal view {
+        if (token == underlying) revert TokenNotAllowedException();
     }
 }

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -34,7 +34,7 @@ import {ClaimAction, ETH_ADDRESS, IWithdrawalManagerV3} from "../interfaces/IWit
 import {IPriceOracleBase} from "@gearbox-protocol/core-v2/contracts/interfaces/IPriceOracleBase.sol";
 import {IUpdatablePriceFeed} from "@gearbox-protocol/core-v2/contracts/interfaces/IPriceFeed.sol";
 
-import {IPoolV3, IPoolBase} from "../interfaces/IPoolV3.sol";
+import {IPoolV3} from "../interfaces/IPoolV3.sol";
 import {IDegenNFTV2} from "@gearbox-protocol/core-v2/contracts/interfaces/IDegenNFTV2.sol";
 import {IWETH} from "@gearbox-protocol/core-v2/contracts/interfaces/external/IWETH.sol";
 import {IBotListV3} from "../interfaces/IBotListV3.sol";

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -46,7 +46,10 @@ import {PERCENTAGE_FACTOR} from "@gearbox-protocol/core-v2/contracts/libraries/C
 import "../interfaces/IExceptions.sol";
 
 /// @title Credit manager V3
-/// @dev Encapsulates the business logic for managing Credit Accounts
+/// @notice Credit manager implements core logic for credit accounts management.
+///         The contract itself is not open to neither external users nor the DAO: users should use `CreditFacadeV3`
+///         to open accounts and perform interactions with external protocols, while the DAO can configure manager
+///         params using `CreditConfiguratorV3`. Both mentioned contracts perform some important safety checks.
 contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardTrait {
     using EnumerableSet for EnumerableSet.AddressSet;
     using BitMask for uint256;

--- a/contracts/credit/CreditManagerV3_USDT.sol
+++ b/contracts/credit/CreditManagerV3_USDT.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.17;
 
 import {CreditManagerV3} from "./CreditManagerV3.sol";
 import {USDT_Transfer} from "../traits/USDT_Transfer.sol";
-import {IPoolV3} from "../interfaces/IPoolV3.sol";
 
-/// @title Credit Manager variation that supports USDT with enabled fees
+/// @title Credit manager V3 USDT
+/// @notice Credit manager variation for USDT underlying with enabled transfer fees
 contract CreditManagerV3_USDT is CreditManagerV3, USDT_Transfer {
     constructor(address _addressProvider, address _pool, string memory _description)
         CreditManagerV3(_addressProvider, _pool, _description)
-        USDT_Transfer(IPoolV3(_pool).underlyingToken())
+        USDT_Transfer(underlying)
     {}
 
     function _amountWithFee(uint256 amount) internal view override returns (uint256) {

--- a/contracts/credit/CreditManagerV3_USDT.sol
+++ b/contracts/credit/CreditManagerV3_USDT.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.17;
 
 import {CreditManagerV3} from "./CreditManagerV3.sol";
 import {USDT_Transfer} from "../traits/USDT_Transfer.sol";
-import {IPoolBase} from "../interfaces/IPoolV3.sol";
+import {IPoolV3} from "../interfaces/IPoolV3.sol";
 
 /// @title Credit Manager variation that supports USDT with enabled fees
 contract CreditManagerV3_USDT is CreditManagerV3, USDT_Transfer {
     constructor(address _addressProvider, address _pool, string memory _description)
         CreditManagerV3(_addressProvider, _pool, _description)
-        USDT_Transfer(IPoolBase(_pool).underlyingToken())
+        USDT_Transfer(IPoolV3(_pool).underlyingToken())
     {}
 
     function _amountWithFee(uint256 amount) internal view override returns (uint256) {

--- a/contracts/interfaces/IAddressProviderV3.sol
+++ b/contracts/interfaces/IAddressProviderV3.sol
@@ -20,6 +20,7 @@ bytes32 constant AP_WITHDRAWAL_MANAGER = "WITHDRAWAL_MANAGER";
 bytes32 constant AP_ROUTER = "ROUTER";
 bytes32 constant AP_BOT_LIST = "BOT_LIST";
 bytes32 constant AP_GEAR_STAKING = "GEAR_STAKING";
+bytes32 constant AP_ZAPPER_REGISTER = "ZAPPER_REGISTER";
 
 interface IAddressProviderV3Events {
     /// @notice Emitted when an address is set for a contract key

--- a/contracts/interfaces/ICreditConfiguratorV3.sol
+++ b/contracts/interfaces/ICreditConfiguratorV3.sol
@@ -10,34 +10,42 @@ enum AllowanceAction {
     ALLOW
 }
 
-/// @dev A struct containing parameters for a recognized collateral token in the system
+/// @notice Struct with collateral token parameters
+/// @param token Token address
+/// @param liquidationThreshold Liquidation threshold in bps
 struct CollateralToken {
-    /// @dev Address of the collateral token
     address token;
-    /// @dev Address of the liquidation threshold
     uint16 liquidationThreshold;
 }
 
-/// @dev A struct representing the initial Credit Manager configuration parameters
+/// @notice Struct with credit manager configuration parameters
+/// @param minDebt Minimum debt amount per account
+/// @param maxDebt Maximum debt amount per account
+/// @param collateralTokens Array of collateral tokens
+/// @param degenNFT Whether to apply Degen NFT whitelist logic
+/// @param expirable Whether facade must be expirable
+/// @param description Credit manager description
 struct CreditManagerOpts {
-    /// @dev The minimal debt principal amount
     uint128 minDebt;
-    /// @dev The maximal debt principal amount
     uint128 maxDebt;
-    /// @dev The initial list of collateral tokens to allow
     CollateralToken[] collateralTokens;
-    /// @dev Address of IDegenNFTV2, address(0) if whitelisted mode is not used
     address degenNFT;
-    /// @dev Whether the Credit Manager is connected to an expirable pool (and the CreditFacadeV3 is expirable)
     bool expirable;
-    /// @dev Description for the Credit Manager
     string description;
 }
 
-interface ICreditConfiguratorEvents {
-    /// @dev Emits when a collateral token's liquidation threshold is changed
+interface ICreditConfiguratorV3Events {
+    // ------ //
+    // TOKENS //
+    // ------ //
+
+    /// @notice Emitted when a token is made recognizable as collateral in the credit manager
+    event AddCollateralToken(address indexed token);
+
+    /// @notice Emitted when a new collateral token liquidation threshold is set
     event SetTokenLiquidationThreshold(address indexed token, uint16 liquidationThreshold);
 
+    /// @notice Emitted when a collateral token liquidation threshold ramping is scheduled
     event ScheduleTokenLiquidationThresholdRamp(
         address indexed token,
         uint16 liquidationThresholdInitial,
@@ -46,22 +54,33 @@ interface ICreditConfiguratorEvents {
         uint40 timestampRampEnd
     );
 
-    /// @dev Emits when a new or a previously forbidden token is allowed
-    event AllowToken(address indexed token);
-
-    /// @dev Emits when a collateral token is forbidden
+    /// @notice Emitted when a collateral token is forbidden
     event ForbidToken(address indexed token);
 
-    /// @dev Emits when a contract <> adapter pair is linked for a Credit Manager
+    /// @notice Emitted when a previously forbidden collateral token is allowed
+    event AllowToken(address indexed token);
+
+    /// @notice Emitted when a token is made quoted
+    event QuoteToken(address indexed token);
+
+    // -------- //
+    // ADAPTERS //
+    // -------- //
+
+    /// @notice Emitted when a new adapter and its target contract are allowed in the credit manager
     event AllowAdapter(address indexed targetContract, address indexed adapter);
 
-    /// @dev Emits when an adapter is forbidden
+    /// @notice Emitted when adapter and its target contract are forbidden in the credit manager
     event ForbidAdapter(address indexed targetContract, address indexed adapter);
 
-    /// @dev Emits when debt principal limits are changed
-    event SetBorrowingLimits(uint256 minDebt, uint256 maxDebt);
+    // -------------- //
+    // CREDIT MANAGER //
+    // -------------- //
 
-    /// @dev Emits when Credit Manager's fee parameters are updated
+    /// @notice Emitted when a new maximum number of enabled tokens is set in the credit manager
+    event SetMaxEnabledTokens(uint8 maxEnabledTokens);
+
+    /// @notice Emitted when new fee parameters are set in the credit manager
     event UpdateFees(
         uint16 feeInterest,
         uint16 feeLiquidation,
@@ -70,70 +89,66 @@ interface ICreditConfiguratorEvents {
         uint16 liquidationPremiumExpired
     );
 
-    /// @dev Emits when a new Price Oracle is connected to the Credit Manager
-    event SetPriceOracle(address indexed newPriceOracle);
+    // -------- //
+    // UPGRADES //
+    // -------- //
 
-    /// @dev Emits when a new Credit Facade is connected to the Credit Manager
-    event SetCreditFacade(address indexed newCreditFacade);
+    /// @notice Emitted when a new price oracle is set in the credit manager
+    event SetPriceOracle(address indexed priceOracle);
 
-    /// @dev Emits when a new Credit Configurator is connected to the Credit Manager
-    event CreditConfiguratorUpgraded(address indexed newCreditConfigurator);
+    /// @notice Emitted when a new bot list is set in the credit facade
+    event SetBotList(address indexed botList);
 
-    /// @dev Emits when the status of the debt increase restriction is changed
-    event AllowBorrowing(); // F:[CC-32]
+    /// @notice Emitted when a new facade is connected to the credit manager
+    event SetCreditFacade(address indexed creditFacade);
 
-    /// @dev Emits when the status of the debt increase restriction is changed
-    event ForbidBorrowing();
+    /// @notice Emitted when credit manager's configurator contract is upgraded
+    event CreditConfiguratorUpgraded(address indexed creditConfigurator);
 
-    /// @dev Emits when the borrowing limit per block is changed
-    event SetMaxDebtPerBlockMultiplier(uint8);
+    // ------------- //
+    // CREDIT FACADE //
+    // ------------- //
 
-    /// @dev Emits when the expiration date is updated in an expirable Credit Facade
-    event SetExpirationDate(uint40);
+    /// @notice Emitted when new debt principal limits are set
+    event SetBorrowingLimits(uint256 minDebt, uint256 maxDebt);
 
-    /// @dev Emits when the enabled token limit is updated
-    event SetMaxEnabledTokens(uint8);
+    /// @notice Emitted when a new max debt per block multiplier is set
+    event SetMaxDebtPerBlockMultiplier(uint8 maxDebtPerBlockMultiplier);
 
-    /// @dev Emits when an address is added to the list of emergency liquidators
-    event AddEmergencyLiquidator(address);
+    /// @notice Emitted when a new max cumulative loss is set
+    event SetMaxCumulativeLoss(uint128 maxCumulativeLoss);
 
-    /// @dev Emits when an address is removed from the list of emergency liquidators
-    event RemoveEmergencyLiquidator(address);
-
-    /// @dev Emits when the bot list is updated in Credit Facade
-    event SetBotList(address);
-
-    /// @dev Emits when the token is set as limited
-    event QuoteToken(address);
-
-    /// @dev Emits when new max cumulative loss is set
-    event SetMaxCumulativeLoss(uint128);
-
-    /// @dev Emits when the current cumulative loss in Credit Facade is reset
+    /// @notice Emitted when cumulative loss is reset to zero in the credit facade
     event ResetCumulativeLoss();
+
+    /// @notice Emitted when a new expiration timestamp is set in the credit facade
+    event SetExpirationDate(uint40 expirationDate);
+
+    /// @notice Emitted when an address is added to the list of emergency liquidators
+    event AddEmergencyLiquidator(address indexed liquidator);
+
+    /// @notice Emitted when an address is removed from the list of emergency liquidators
+    event RemoveEmergencyLiquidator(address indexed liquidator);
 }
 
-/// @dev CreditConfiguratorV3 Exceptions
+/// @title Credit configurator V3 interface
+interface ICreditConfiguratorV3 is IVersion, ICreditConfiguratorV3Events {
+    function addressProvider() external view returns (address);
 
-interface ICreditConfiguratorV3 is ICreditConfiguratorEvents, IVersion {
-    //
-    // STATE-CHANGING FUNCTIONS
-    //
+    function creditManager() external view returns (address);
 
-    /// @dev Adds token to the list of allowed collateral tokens, and sets the LT
-    /// @param token Address of token to be added
-    /// @param liquidationThreshold Liquidation threshold for account health calculations
+    function creditFacade() external view returns (address);
+
+    function underlying() external view returns (address);
+
+    // ------ //
+    // TOKENS //
+    // ------ //
+
     function addCollateralToken(address token, uint16 liquidationThreshold) external;
 
-    /// @dev Sets a liquidation threshold for any token except the underlying
-    /// @param token Token address
-    /// @param liquidationThreshold in PERCENTAGE_FORMAT (100% = 10000)
     function setLiquidationThreshold(address token, uint16 liquidationThreshold) external;
 
-    /// @dev Schedules an LT ramping for any token except underlying
-    /// @param token Token to ramp LT for
-    /// @param liquidationThresholdFinal Liquidation threshold after ramping
-    /// @param rampDuration Duration of ramping
     function rampLiquidationThreshold(
         address token,
         uint16 liquidationThresholdFinal,
@@ -141,41 +156,26 @@ interface ICreditConfiguratorV3 is ICreditConfiguratorEvents, IVersion {
         uint24 rampDuration
     ) external;
 
-    /// @dev Allow a known collateral token if it was forbidden before.
-    /// @param token Address of collateral token
-    function allowToken(address token) external;
-
-    /// @dev Forbids a collateral token.
-    /// Forbidden tokens are counted as collateral during health checks, however, they cannot be enabled
-    /// or received as a result of adapter operation anymore. This means that a token can never be
-    /// acquired through adapter operations after being forbidden.
-    /// @param token Address of collateral token to forbid
     function forbidToken(address token) external;
 
-    /// @dev Adds pair [contract <-> adapter] to the list of allowed contracts
-    /// or updates adapter address if a contract already has a connected adapter
-    /// @dev The target contract is retrieved from the adapter
-    /// @param adapter Adapter address
+    function allowToken(address token) external;
+
+    function makeTokenQuoted(address token) external;
+
+    // -------- //
+    // ADAPTERS //
+    // -------- //
+
+    function allowedAdapters() external view returns (address[] memory);
+
     function allowAdapter(address adapter) external;
 
-    /// @dev Forbids contract as a target for calls from Credit Accounts
-    /// @param targetContract Address of a contract to be forbidden
-    function forbidAdapter(address targetContract) external;
+    function forbidAdapter(address adapter) external;
 
-    /// @notice Sets the minimal borrowed amount limit in Credit Facade
-    /// @param minDebt Minimum borrowed amount
-    function setMinDebtLimit(uint128 minDebt) external;
+    // -------------- //
+    // CREDIT MANAGER //
+    // -------------- //
 
-    /// @notice Sets the maximal borrowed amount limit in Credit Facade
-    /// @param maxDebt Maximum borrowed amount
-    function setMaxDebtLimit(uint128 maxDebt) external;
-
-    /// @dev Sets fees for creditManager
-    /// @param feeInterest Percent which protocol charges additionally for interest rate
-    /// @param feeLiquidation The fee that is paid to the pool from liquidation
-    /// @param liquidationPremium Discount for totalValue which is given to liquidator
-    /// @param feeLiquidationExpired The fee that is paid to the pool from liquidation when liquidating an expired account
-    /// @param liquidationPremiumExpired Discount for totalValue which is given to liquidator when liquidating an expired account
     function setFees(
         uint16 feeInterest,
         uint16 feeLiquidation,
@@ -184,86 +184,41 @@ interface ICreditConfiguratorV3 is ICreditConfiguratorEvents, IVersion {
         uint16 liquidationPremiumExpired
     ) external;
 
-    /// @dev Upgrades the price oracle in the Credit Manager, taking the address
-    /// from the address provider
-    function setPriceOracle(uint256 version) external;
+    function setMaxEnabledTokens(uint8 newMaxEnabledTokens) external;
 
-    /// @dev Upgrades the Credit Facade corresponding to the Credit Manager
-    /// @param creditFacade address of the new CreditFacadeV3
-    /// @param migrateParams Whether the previous CreditFacadeV3's parameter need to be copied
-    function setCreditFacade(address creditFacade, bool migrateParams) external;
+    // -------- //
+    // UPGRADES //
+    // -------- //
 
-    /// @dev Upgrades the Credit Configurator for a connected Credit Manager
-    /// @param creditConfigurator New Credit Configurator's address
-    function upgradeCreditConfigurator(address creditConfigurator) external;
+    function setPriceOracle(uint256 newVersion) external;
 
-    /// @dev Sets the maximal borrowed amount per block as multiplier to maxDebt
+    function setBotList(uint256 newVersion) external;
+
+    function setCreditFacade(address newCreditFacade, bool migrateParams) external;
+
+    function upgradeCreditConfigurator(address newCreditConfigurator) external;
+
+    // ------------- //
+    // CREDIT FACADE //
+    // ------------- //
+
+    function setMinDebtLimit(uint128 newMinDebt) external;
+
+    function setMaxDebtLimit(uint128 newMaxDebt) external;
+
     function setMaxDebtPerBlockMultiplier(uint8 newMaxDebtLimitPerBlockMultiplier) external;
 
-    /// @dev Sets expiration date in a CreditFacadeV3 connected
-    /// To a CreditManagerV3 with an expirable pool
-    /// @param newExpirationDate The timestamp of the next expiration
-    function setExpirationDate(uint40 newExpirationDate) external;
-
-    /// @dev Sets the maximal amount of enabled tokens per Credit Account
-    /// @param maxEnabledTokens The new maximal number of enabled tokens
-    /// @notice A large number of enabled collateral tokens on a Credit Account
-    /// can make liquidations and health checks prohibitively expensive in terms of gas,
-    /// hence the number is limited
-    function setMaxEnabledTokens(uint8 maxEnabledTokens) external;
-
-    /// @dev Adds an address to the list of emergency liquidators
-    /// @param liquidator The address to add to the list
-    /// @notice Emergency liquidators are trusted addresses
-    /// that are able to liquidate positions while the contracts are paused,
-    /// e.g. when there is a risk of bad debt while an exploit is being patched.
-    /// In the interest of fairness, emergency liquidators do not receive a premium
-    /// And are compensated by the Gearbox DAO separately.
-    function addEmergencyLiquidator(address liquidator) external;
-
-    /// @dev Removex an address frp, the list of emergency liquidators
-    /// @param liquidator The address to remove from the list
-    function removeEmergencyLiquidator(address liquidator) external;
-
-    /// @dev Sets the max cumulative loss, which is a threshold of total loss that triggers a system pause
-    /// @param _maxCumulativeLoss The new value for maximal cumulative loss
-    function setMaxCumulativeLoss(uint128 _maxCumulativeLoss) external;
-
-    /// @dev Resets the current cumulative loss in Credit Facade
-    function resetCumulativeLoss() external;
-
-    /// @notice Disables borrowing in Credit Facade
     function forbidBorrowing() external;
 
-    /// @dev Sets the bot list contract
-    /// @param version The version of the new bot list contract
-    ///                The contract address is retrieved from addressProvider
-    function setBotList(uint256 version) external;
+    function setMaxCumulativeLoss(uint128 newMaxCumulativeLoss) external;
 
-    /// @notice Marks the token as limited, which enables quota logic and additional interest for it
-    /// @param token Token to make limited
-    /// @dev This action is irreversible!
-    function makeTokenQuoted(address token) external;
+    function resetCumulativeLoss() external;
 
-    //
-    // GETTERS
-    //
+    function setExpirationDate(uint40 newExpirationDate) external;
 
-    /// @dev Address provider (needed for upgrading the Price Oracle)
-    function addressProvider() external view returns (address);
-
-    /// @dev Returns the Credit Facade currently connected to the Credit Manager
-    function creditFacade() external view returns (address);
-
-    /// @dev Address of the Credit Manager
-    function creditManager() external view returns (address);
-
-    /// @dev Address of the Credit Manager's underlying asset
-    function underlying() external view returns (address);
-
-    /// @dev Returns all allowed adapters
-    function allowedAdapters() external view returns (address[] memory);
-
-    /// @dev Returns all emergency liquidators
     function emergencyLiquidators() external view returns (address[] memory);
+
+    function addEmergencyLiquidator(address liquidator) external;
+
+    function removeEmergencyLiquidator(address liquidator) external;
 }

--- a/contracts/interfaces/ICreditManagerV3.sol
+++ b/contracts/interfaces/ICreditManagerV3.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 
 import {IVersion} from "@gearbox-protocol/core-v2/contracts/interfaces/IVersion.sol";
 
-import {ClaimAction, IWithdrawalManagerV3} from "./IWithdrawalManagerV3.sol";
+import {ClaimAction} from "./IWithdrawalManagerV3.sol";
 
 uint8 constant WITHDRAWAL_FLAG = 1;
 uint8 constant BOT_PERMISSIONS_SET_FLAG = 1 << 1;

--- a/contracts/interfaces/IPoolV3.sol
+++ b/contracts/interfaces/IPoolV3.sol
@@ -7,16 +7,6 @@ pragma abicoder v1;
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IVersion} from "@gearbox-protocol/core-v2/contracts/interfaces/IVersion.sol";
 
-/// @title Pool base interface
-/// @notice Functions shared accross newer and older versions
-interface IPoolBase is IVersion {
-    function addressProvider() external view returns (address);
-    function underlyingToken() external view returns (address);
-    function calcLinearCumulative_RAY() external view returns (uint256);
-    function lendCreditAccount(uint256 borrowedAmount, address creditAccount) external;
-    function repayCreditAccount(uint256 repaidAmount, uint256 profit, uint256 loss) external;
-}
-
 interface IPoolV3Events {
     /// @notice Emitted when depositing liquidity with referral code
     event Refer(address indexed onBehalfOf, uint256 indexed referralCode, uint256 amount);
@@ -50,10 +40,10 @@ interface IPoolV3Events {
 }
 
 /// @title Pool V3 interface
-interface IPoolV3 is IPoolV3Events, IPoolBase, IERC4626 {
-    function addressProvider() external view override returns (address);
+interface IPoolV3 is IVersion, IPoolV3Events, IERC4626 {
+    function addressProvider() external view returns (address);
 
-    function underlyingToken() external view override returns (address);
+    function underlyingToken() external view returns (address);
 
     function treasury() external view returns (address);
 
@@ -93,9 +83,9 @@ interface IPoolV3 is IPoolV3Events, IPoolBase, IERC4626 {
 
     function creditManagerBorrowable(address creditManager) external view returns (uint256 borrowable);
 
-    function lendCreditAccount(uint256 borrowedAmount, address creditAccount) external override;
+    function lendCreditAccount(uint256 borrowedAmount, address creditAccount) external;
 
-    function repayCreditAccount(uint256 repaidAmount, uint256 profit, uint256 loss) external override;
+    function repayCreditAccount(uint256 repaidAmount, uint256 profit, uint256 loss) external;
 
     // ------------- //
     // INTEREST RATE //
@@ -108,8 +98,6 @@ interface IPoolV3 is IPoolV3Events, IPoolBase, IERC4626 {
     function supplyRate() external view returns (uint256);
 
     function baseInterestIndex() external view returns (uint256);
-
-    function calcLinearCumulative_RAY() external view override returns (uint256);
 
     function baseInterestIndexLU() external view returns (uint256);
 

--- a/contracts/pool/PoolV3.sol
+++ b/contracts/pool/PoolV3.sol
@@ -527,11 +527,6 @@ contract PoolV3 is ERC4626, ACLNonReentrantTrait, ContractsRegisterTrait, IPoolV
         return _calcBaseInterestIndex(timestampLU); // U:[LP-16]
     }
 
-    /// @dev Same as `baseInterestIndex`, kept for backward compatibility
-    function calcLinearCumulative_RAY() external view override returns (uint256) {
-        return baseInterestIndex();
-    }
-
     /// @notice Cumulative base interest index stored as of last update in ray
     function baseInterestIndexLU() external view override returns (uint256) {
         return _baseInterestIndexLU;

--- a/contracts/pool/PoolV3_USDT.sol
+++ b/contracts/pool/PoolV3_USDT.sol
@@ -7,7 +7,7 @@ import {PoolV3} from "./PoolV3.sol";
 import {USDT_Transfer} from "../traits/USDT_Transfer.sol";
 
 /// @title Pool V3 USDT
-/// @notice Pool implementation for USDT which has optional transfer fee
+/// @notice Pool variation for USDT underlying with enabled transfer fees
 contract PoolV3_USDT is PoolV3, USDT_Transfer {
     constructor(
         address addressProvider_,

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -451,7 +451,7 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
     {
         debt = creditAccountAmount;
 
-        cumulativeIndexLastUpdate = pool.calcLinearCumulative_RAY();
+        cumulativeIndexLastUpdate = pool.baseInterestIndex();
         // pool.setCumulativeIndexNow(cumulativeIndexLastUpdate);
 
         vm.prank(address(creditFacade));

--- a/contracts/test/integration/credit/CloseCreditAccount.int.sol
+++ b/contracts/test/integration/credit/CloseCreditAccount.int.sol
@@ -46,7 +46,7 @@ import {GeneralMock} from "../../mocks//GeneralMock.sol";
 
 import {Tokens} from "@gearbox-protocol/sdk-gov/contracts/Tokens.sol";
 
-import {IPoolBase} from "../../../interfaces/IPoolV3.sol";
+import {IPoolV3} from "../../../interfaces/IPoolV3.sol";
 
 import "forge-std/console.sol";
 
@@ -262,7 +262,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
         vm.warp(block.timestamp + 365 days);
         vm.roll(block.number + 1);
 
-        uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         uint256 interestAccrued = (debt * cumulativeIndexAtClose) / cumulativeIndexLastUpdate - debt;
 
@@ -272,7 +272,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
 
         uint256 amountToPool = debt + interestAccrued + profit;
 
-        vm.expectCall(address(pool), abi.encodeCall(IPoolBase.repayCreditAccount, (debt, profit, 0)));
+        vm.expectCall(address(pool), abi.encodeCall(IPoolV3.repayCreditAccount, (debt, profit, 0)));
 
         vm.prank(USER);
         creditFacade.closeCreditAccount(creditAccount, FRIEND, 0, false, new MultiCall[](0));
@@ -324,7 +324,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
         vm.warp(block.timestamp + warpTime);
         vm.roll(block.number + 1);
 
-        uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         uint256 interestAccrued = (debt * cumulativeIndexAtClose) / cumulativeIndexLastUpdate - debt;
 
@@ -340,7 +340,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
 
             uint256 poolBalanceBefore = tokenTestSuite.balanceOf(Tokens.DAI, address(pool));
 
-            vm.expectCall(address(pool), abi.encodeCall(IPoolBase.repayCreditAccount, (debt, profit, 0)));
+            vm.expectCall(address(pool), abi.encodeCall(IPoolV3.repayCreditAccount, (debt, profit, 0)));
 
             vm.prank(USER);
             creditFacade.closeCreditAccount(creditAccount, FRIEND, 0, false, new MultiCall[](0));
@@ -424,7 +424,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
             // }
             vm.roll(block.number + 1);
 
-            uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+            uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
             interestAccrued = (debt * cumulativeIndexAtClose) / cumulativeIndexLastUpdate - debt;
         }
@@ -444,7 +444,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
         {
             uint256 loss = debt + interestAccrued - amountToPool;
 
-            vm.expectCall(address(pool), abi.encodeCall(IPoolBase.repayCreditAccount, (debt, 0, loss)));
+            vm.expectCall(address(pool), abi.encodeCall(IPoolV3.repayCreditAccount, (debt, 0, loss)));
         }
 
         vm.prank(LIQUIDATOR);
@@ -530,7 +530,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
 
         // vm.warp(block.timestamp + 365 days);
 
-        // uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        // uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         // uint256 interestAccrued = (debt * cumulativeIndexAtClose) / cumulativeIndexLastUpdate - debt;
 

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -16,7 +16,7 @@ import {
     IVersion
 } from "../../../credit/CreditConfiguratorV3.sol";
 import {ICreditManagerV3} from "../../../interfaces/ICreditManagerV3.sol";
-import {ICreditConfiguratorEvents} from "../../../interfaces/ICreditConfiguratorV3.sol";
+import {ICreditConfiguratorV3Events} from "../../../interfaces/ICreditConfiguratorV3.sol";
 import {IAdapter} from "@gearbox-protocol/core-v2/contracts/interfaces/IAdapter.sol";
 
 //
@@ -44,7 +44,7 @@ import {MockCreditConfig, CollateralTokenHuman} from "../../config/MockCreditCon
 
 import "forge-std/console.sol";
 
-contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConfiguratorEvents {
+contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConfiguratorV3Events {
     using AddressList for address[];
 
     // function setUp() public creditTest {
@@ -282,7 +282,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
         );
 
         vm.expectEmit(true, false, false, false);
-        emit AllowToken(usdcToken);
+        emit AddCollateralToken(usdcToken);
 
         vm.expectEmit(true, false, false, true);
         emit SetTokenLiquidationThreshold(usdcToken, 6000);
@@ -417,7 +417,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
         address newToken = tokenTestSuite.addressOf(Tokens.wstETH);
 
         vm.expectEmit(true, false, false, false);
-        emit AllowToken(newToken);
+        emit AddCollateralToken(newToken);
 
         vm.prank(CONFIGURATOR);
         creditConfigurator.addCollateralToken(newToken, 8800);

--- a/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
+++ b/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
@@ -219,7 +219,7 @@ contract LiquidateCreditAccountIntegrationTest is IntegrationTestHelper, ICredit
 
         //     vm.warp(block.timestamp + 365 days);
 
-        //     uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        //     uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         //     interestAccrued = (debt * cumulativeIndexAtClose) / cumulativeIndexLastUpdate - debt;
 

--- a/contracts/test/integration/credit/ManageDebt.int.t.sol
+++ b/contracts/test/integration/credit/ManageDebt.int.t.sol
@@ -306,7 +306,7 @@ contract ManegDebtIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Event
         //     assertEq(cumulativeIndexLastUpdateAfter, cumulativeIndexNow, "Incorrect cumulativeIndexLastUpdate");
         // } else {
         //     CreditManagerTestInternal cmi = new CreditManagerTestInternal(
-        //         creditManager.poolService(), address(withdrawalManager)
+        //         creditManager.pool(), address(withdrawalManager)
         //     );
 
         //     {

--- a/contracts/test/integration/credit/OpenCreditAccount.int.t.sol
+++ b/contracts/test/integration/credit/OpenCreditAccount.int.t.sol
@@ -49,7 +49,7 @@ contract OpenCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFacad
             AccountFactory(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL)).head();
 
         uint256 blockAtOpen = block.number;
-        uint256 cumulativeAtOpen = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeAtOpen = pool.baseInterestIndex();
         // pool.setCumulativeIndexNow(cumulativeAtOpen);
 
         tokenTestSuite.mint(Tokens.DAI, USER, DAI_ACCOUNT_AMOUNT);
@@ -251,7 +251,7 @@ contract OpenCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFacad
         amount = bound(amount, 10000, DAI_ACCOUNT_AMOUNT);
         vm.assume(token1 > 0 && token1 < creditManager.collateralTokensCount());
 
-        tokenTestSuite.mint(Tokens.DAI, address(creditManager.poolService()), type(uint96).max);
+        tokenTestSuite.mint(Tokens.DAI, address(creditManager.pool()), type(uint96).max);
 
         vm.prank(CONFIGURATOR);
         creditConfigurator.setMaxDebtPerBlockMultiplier(type(uint8).max);
@@ -417,7 +417,7 @@ contract OpenCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFacad
             AccountFactory(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL)).head();
 
         uint256 blockAtOpen = block.number;
-        uint256 cumulativeAtOpen = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeAtOpen = pool.baseInterestIndex();
         // pool.setCumulativeIndexNow(cumulativeAtOpen);
 
         MultiCall[] memory calls = MultiCallBuilder.build();

--- a/contracts/test/integration/credit/Quotas.int.t.sol
+++ b/contracts/test/integration/credit/Quotas.int.t.sol
@@ -292,7 +292,7 @@ contract QuotasIntegrationTest is IntegrationTestHelper, ICreditManagerV3Events 
         vm.warp(block.timestamp + 365 days);
         vm.roll(block.number + 100);
 
-        uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         (uint16 feeInterest,,,,) = creditManager.fees();
 
@@ -361,7 +361,7 @@ contract QuotasIntegrationTest is IntegrationTestHelper, ICreditManagerV3Events 
 
         vm.warp(block.timestamp + 365 days);
 
-        uint256 cumulativeIndexAtClose = pool.calcLinearCumulative_RAY();
+        uint256 cumulativeIndexAtClose = pool.baseInterestIndex();
 
         (uint16 feeInterest,,,,) = creditManager.fees();
 

--- a/contracts/test/mocks/pool/PoolMock.sol
+++ b/contracts/test/mocks/pool/PoolMock.sol
@@ -99,6 +99,10 @@ contract PoolMock is IPoolService {
         _cumulativeIndex_RAY = cumulativeIndex_RAY;
     }
 
+    function baseInterestIndex() public view returns (uint256) {
+        return _cumulativeIndex_RAY;
+    }
+
     function calcLinearCumulative_RAY() public view override returns (uint256) {
         return _cumulativeIndex_RAY;
     }
@@ -216,19 +220,4 @@ contract PoolMock is IPoolService {
     function setExpectedLiquidityLimit(uint256 num) external {}
 
     function setWithdrawFee(uint256 num) external {}
-
-    //    function calcCumulativeIndexAtBorrowMore(
-    //        uint256 amount,
-    //        uint256 dAmount,
-    //        uint256 cumulativeIndexLastUpdate
-    //    ) external view override returns (uint256) {
-    //        return
-    //            (calcLinearCumulative_RAY() *
-    //                (cumulativeIndexLastUpdate) *
-    //                (amount + dAmount)) /
-    //            (calcLinearCumulative_RAY() *
-    //                amount +
-    //                dAmount *
-    //                cumulativeIndexLastUpdate);
-    //    }
 }

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -2132,13 +2132,13 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         });
     }
 
-    /// @dev U:[FA-42]: eraseAllBotPermissionsAtClosure works properly
-    function test_U_FA_42_eraseAllBotPermissionsAtClosure_works_properly() public notExpirableCase {
+    /// @dev U:[FA-42]: eraseAllBotPermissions works properly
+    function test_U_FA_42_eraseAllBotPermissions_works_properly() public notExpirableCase {
         address creditAccount = DUMB_ADDRESS;
 
         botListMock.setRevertOnErase(true);
         creditManagerMock.setFlagFor({creditAccount: creditAccount, flag: BOT_PERMISSIONS_SET_FLAG, value: false});
-        creditFacade.eraseAllBotPermissionsAtClosure(creditAccount);
+        creditFacade.eraseAllBotPermissions(creditAccount);
 
         botListMock.setRevertOnErase(false);
         creditManagerMock.setFlagFor({creditAccount: creditAccount, flag: BOT_PERMISSIONS_SET_FLAG, value: true});
@@ -2146,7 +2146,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
             address(botListMock),
             abi.encodeCall(IBotListV3.eraseAllBotPermissions, (address(creditManagerMock), creditAccount))
         );
-        creditFacade.eraseAllBotPermissionsAtClosure(creditAccount);
+        creditFacade.eraseAllBotPermissions(creditAccount);
     }
 
     /// @dev U:[FA-43]: revertIfOutOfBorrowingLimit works properly
@@ -2253,7 +2253,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
 
         // Case: it sets parameters properly
         vm.prank(CONFIGURATOR);
-        creditFacade.setDebtLimits({_minDebt: 1, _maxDebt: 2, _maxDebtPerBlockMultiplier: 3});
+        creditFacade.setDebtLimits({newMinDebt: 1, newMaxDebt: 2, newMaxDebtPerBlockMultiplier: 3});
 
         maxDebtPerBlockMultiplier = creditFacade.maxDebtPerBlockMultiplier();
         (minDebt, maxDebt) = creditFacade.debtLimits();

--- a/contracts/test/unit/credit/CreditFacadeV3Harness.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3Harness.sol
@@ -32,8 +32,8 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
         _revertIfNoPermission(flags, permission);
     }
 
-    function eraseAllBotPermissionsAtClosure(address creditAccount) external {
-        _eraseAllBotPermissionsAtClosure(creditAccount);
+    function eraseAllBotPermissions(address creditAccount) external {
+        _eraseAllBotPermissions(creditAccount);
     }
 
     function revertIfOutOfBorrowingLimit(uint256 amount) external {

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -285,8 +285,6 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
 
     /// @dev U:[CM-1]: credit manager reverts if were called non-creditFacade
     function test_U_CM_01_constructor_sets_correct_values() public creditManagerTest {
-        assertEq(address(creditManager.poolService()), address(poolMock), _testCaseErr("Incorrect poolService"));
-
         assertEq(address(creditManager.pool()), address(poolMock), _testCaseErr("Incorrect pool"));
 
         assertEq(creditManager.underlying(), tokenTestSuite.addressOf(Tokens.DAI), _testCaseErr("Incorrect underlying"));

--- a/contracts/test/unit/credit/CreditManagerV3Harness_USDT.sol
+++ b/contracts/test/unit/credit/CreditManagerV3Harness_USDT.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.8.17;
 
 import {CreditManagerV3Harness} from "./CreditManagerV3Harness.sol";
 import {USDT_Transfer} from "../../../traits/USDT_Transfer.sol";
-import {IPoolBase} from "../../../interfaces/IPoolV3.sol";
-/// @title Credit Manager
+import {IPoolV3} from "../../../interfaces/IPoolV3.sol";
 
+/// @title Credit Manager
 contract CreditManagerV3Harness_USDT is CreditManagerV3Harness, USDT_Transfer {
     constructor(address _addressProvider, address _pool, string memory _description)
         CreditManagerV3Harness(_addressProvider, _pool, _description)
-        USDT_Transfer(IPoolBase(_pool).underlyingToken())
+        USDT_Transfer(IPoolV3(_pool).underlyingToken())
     {}
 
     function _amountWithFee(uint256 amount) internal view override returns (uint256) {


### PR DESCRIPTION
In this PR:
* fix a case where emergency liquidation could revert
* deprecate some backward-compatibility methods from credit manager and pool
* add `AP_ZAPPER_REGISTER`
* minor code refactoring
* mostly changing comments and interfaces