### PR TITLE
fix: minor cleanup

### DIFF
--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -77,9 +77,6 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     /// @notice Maximum quota size, as a multiple of `maxDebt`
     uint256 public constant override maxQuotaMultiplier = 8;
 
-    /// @notice Maximum number of approved bots for a credit account
-    uint256 public constant override maxApprovedBots = 5;
-
     /// @notice Credit manager connected to this credit facade
     address public immutable override creditManager;
 
@@ -158,9 +155,9 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     {
         creditManager = _creditManager; // U:[FA-1]
 
-        weth = ICreditManagerV3(_creditManager).weth(); // U:[FA-1]
-        botList =
-            IAddressProviderV3(ICreditManagerV3(_creditManager).addressProvider()).getAddressOrRevert(AP_BOT_LIST, 3_00);
+        address addressProvider = ICreditManagerV3(_creditManager).addressProvider();
+        weth = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_WETH_TOKEN, NO_VERSION_CONTROL); // U:[FA-1]
+        botList = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_BOT_LIST, 3_00); // U:[FA-1]
 
         degenNFT = _degenNFT; // U:[FA-1]
 
@@ -428,10 +425,6 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
             creditAccount: creditAccount,
             permissions: permissions
         }); // U:[FA-41]
-
-        if (remainingBots > maxApprovedBots) {
-            revert TooManyApprovedBotsException(); // U:[FA-41]
-        }
 
         if (remainingBots == 0) {
             _setFlagFor({creditAccount: creditAccount, flag: BOT_PERMISSIONS_SET_FLAG, value: false}); // U:[FA-41]

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -72,9 +72,6 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @notice Address of the pool credit manager is connected to
     address public immutable override pool;
 
-    /// @notice WETH token address
-    address public immutable override weth;
-
     /// @notice Address of the connected credit facade
     address public override creditFacade;
 
@@ -162,7 +159,6 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         underlying = IPoolV3(_pool).underlyingToken(); // U:[CM-1]
         _addToken(underlying); // U:[CM-1]
 
-        weth = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_WETH_TOKEN, NO_VERSION_CONTROL); // U:[CM-1]
         priceOracle = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_PRICE_ORACLE, 3_00); // U:[CM-1]
         accountFactory = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL); // U:[CM-1]
 

--- a/contracts/interfaces/ICreditFacadeV3.sol
+++ b/contracts/interfaces/ICreditFacadeV3.sol
@@ -90,8 +90,6 @@ interface ICreditFacadeV3 is IVersion, ICreditFacadeV3Events {
 
     function maxQuotaMultiplier() external view returns (uint256);
 
-    function maxApprovedBots() external view returns (uint256);
-
     function expirable() external view returns (bool);
 
     function expirationDate() external view returns (uint40);

--- a/contracts/interfaces/ICreditManagerV3.sol
+++ b/contracts/interfaces/ICreditManagerV3.sol
@@ -98,8 +98,6 @@ interface ICreditManagerV3 is IVersion, ICreditManagerV3Events {
 
     function accountFactory() external view returns (address);
 
-    function weth() external view returns (address);
-
     function name() external view returns (string memory);
 
     // ------------------ //

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -208,9 +208,6 @@ error NotApprovedBotException();
 /// @notice Thrown when attempting to perform a multicall action with no permission for it
 error NoPermissionException(uint256 permission);
 
-/// @notice Thrown when user tries to approve more bots than allowed
-error TooManyApprovedBotsException();
-
 /// @notice Thrown when attempting to give a bot unexpected permissions
 error UnexpectedPermissionsException();
 

--- a/contracts/test/mocks/credit/CreditManagerMock.sol
+++ b/contracts/test/mocks/credit/CreditManagerMock.sol
@@ -29,9 +29,6 @@ contract CreditManagerMock {
     address public poolService;
     address public pool;
 
-    /// @dev Address of WETH
-    address public weth;
-
     /// @dev Address of withdrawal manager
     address public withdrawalManager;
 
@@ -83,7 +80,6 @@ contract CreditManagerMock {
 
     constructor(address _addressProvider, address _pool) {
         addressProvider = _addressProvider;
-        weth = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_WETH_TOKEN, NO_VERSION_CONTROL);
         setPoolService(_pool);
         creditConfigurator = CONFIGURATOR;
     }

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -180,7 +180,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
     function test_U_FA_01_constructor_sets_correct_values() public allDegenNftCases allExpirableCases {
         assertEq(address(creditFacade.creditManager()), address(creditManagerMock), "Incorrect creditManager");
 
-        assertEq(creditFacade.weth(), creditManagerMock.weth(), "Incorrect weth token");
+        assertEq(creditFacade.weth(), tokenTestSuite.addressOf(Tokens.WETH), "Incorrect weth token");
 
         assertEq(creditFacade.degenNFT(), address(degenNFTMock), "Incorrect degen NFT");
     }
@@ -1783,12 +1783,6 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
             abi.encodeCall(IBotListV3.setBotPermissions, (bot, address(creditManagerMock), creditAccount, 1))
         );
 
-        vm.prank(USER);
-        creditFacade.setBotPermissions({creditAccount: creditAccount, bot: bot, permissions: 1});
-
-        /// It reverts if too many bots approved
-        botListMock.setBotPermissionsReturn(creditFacade.maxApprovedBots() + 1);
-        vm.expectRevert(TooManyApprovedBotsException.selector);
         vm.prank(USER);
         creditFacade.setBotPermissions({creditAccount: creditAccount, bot: bot, permissions: 1});
 

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -119,7 +119,6 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         underlying = tokenTestSuite.addressOf(Tokens.DAI);
 
         addressProvider = new AddressProviderV3ACLMock();
-        addressProvider.setAddress(AP_WETH_TOKEN, tokenTestSuite.addressOf(Tokens.WETH), false);
 
         accountFactory = AccountFactoryMock(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL));
 
@@ -291,12 +290,6 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         );
 
         // assertEq(lt, 0, _testCaseErr("Incorrect LT for underlying"));
-
-        assertEq(
-            creditManager.weth(),
-            addressProvider.getAddressOrRevert(AP_WETH_TOKEN, 0),
-            _testCaseErr("Incorrect WETH token")
-        );
 
         assertEq(
             address(creditManager.priceOracle()),


### PR DESCRIPTION
* remove `weth` from `CreditManagerV3` as it is no longer referenced there
* remove restriction on number of approved bots as it can't be used to block liqudiations anymore