### PR TITLE
test: improve fuzzing tests

### DIFF
--- a/contracts/libraries/CreditLogic.sol
+++ b/contracts/libraries/CreditLogic.sol
@@ -209,12 +209,12 @@ library CreditLogic {
         unchecked {
             if (quotaFees != 0) {
                 if (amountToRepay > quotaFees) {
-                    newQuotaFees = 0;
+                    newQuotaFees = 0; // U:[CL-3]
                     amountToRepay -= quotaFees;
-                    profit = quotaFees;
+                    profit = quotaFees; // U:[CL-3]
                 } else {
-                    newQuotaFees = quotaFees - uint128(amountToRepay);
-                    profit = amountToRepay;
+                    newQuotaFees = quotaFees - uint128(amountToRepay); // U:[CL-3]
+                    profit = amountToRepay; // U:[CL-3]
                     amountToRepay = 0;
                 }
             }
@@ -224,18 +224,18 @@ library CreditLogic {
             uint256 quotaProfit = (cumulativeQuotaInterest * feeInterest) / PERCENTAGE_FACTOR;
 
             if (amountToRepay >= cumulativeQuotaInterest + quotaProfit) {
-                amountToRepay -= cumulativeQuotaInterest + quotaProfit; // U:[CL-3B]
-                profit += quotaProfit; // U:[CL-3B]
+                amountToRepay -= cumulativeQuotaInterest + quotaProfit; // U:[CL-3]
+                profit += quotaProfit; // U:[CL-3]
 
-                newCumulativeQuotaInterest = 0; // U:[CL-3A]
+                newCumulativeQuotaInterest = 0; // U:[CL-3]
             } else {
                 // If amount is not enough to repay quota interest + DAO fee, then it is split pro-rata between them
                 uint256 amountToPool = (amountToRepay * PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + feeInterest);
 
-                profit += amountToRepay - amountToPool; // U:[CL-3B]
-                amountToRepay = 0; // U:[CL-3B]
+                profit += amountToRepay - amountToPool; // U:[CL-3]
+                amountToRepay = 0; // U:[CL-3]
 
-                newCumulativeQuotaInterest = uint128(cumulativeQuotaInterest - amountToPool); // U:[CL-3A]
+                newCumulativeQuotaInterest = uint128(cumulativeQuotaInterest - amountToPool); // U:[CL-3]
             }
         } else {
             newCumulativeQuotaInterest = cumulativeQuotaInterest;
@@ -246,31 +246,31 @@ library CreditLogic {
                 amount: debt,
                 cumulativeIndexLastUpdate: cumulativeIndexLastUpdate,
                 cumulativeIndexNow: cumulativeIndexNow
-            }); // U:[CL-3A]
-            uint256 profitFromInterest = (interestAccrued * feeInterest) / PERCENTAGE_FACTOR; // U:[CL-3A]
+            }); // U:[CL-3]
+            uint256 profitFromInterest = (interestAccrued * feeInterest) / PERCENTAGE_FACTOR; // U:[CL-3]
 
             if (amountToRepay >= interestAccrued + profitFromInterest) {
                 amountToRepay -= interestAccrued + profitFromInterest;
 
-                profit += profitFromInterest; // U:[CL-3B]
+                profit += profitFromInterest; // U:[CL-3]
 
-                newCumulativeIndex = cumulativeIndexNow; // U:[CL-3A]
+                newCumulativeIndex = cumulativeIndexNow; // U:[CL-3]
             } else {
                 // If amount is not enough to repay base interest + DAO fee, then it is split pro-rata between them
                 uint256 amountToPool = (amountToRepay * PERCENTAGE_FACTOR) / (PERCENTAGE_FACTOR + feeInterest);
 
-                profit += amountToRepay - amountToPool; // U:[CL-3B]
-                amountToRepay = 0; // U:[CL-3B]
+                profit += amountToRepay - amountToPool; // U:[CL-3]
+                amountToRepay = 0; // U:[CL-3]
 
                 newCumulativeIndex = (INDEX_PRECISION * cumulativeIndexNow * cumulativeIndexLastUpdate)
                     / (
                         INDEX_PRECISION * cumulativeIndexNow
                             - (INDEX_PRECISION * amountToPool * cumulativeIndexLastUpdate) / debt
-                    ); // U:[CL-3A]
+                    ); // U:[CL-3]
             }
         } else {
-            newCumulativeIndex = cumulativeIndexLastUpdate; // U:[CL-3A]
+            newCumulativeIndex = cumulativeIndexLastUpdate; // U:[CL-3]
         }
-        newDebt = debt - amountToRepay; // U:[CL-3A]
+        newDebt = debt - amountToRepay; // U:[CL-3]
     }
 }

--- a/contracts/test/integration/credit/OpenCreditAccount.int.t.sol
+++ b/contracts/test/integration/credit/OpenCreditAccount.int.t.sol
@@ -261,7 +261,7 @@ contract OpenCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFacad
         creditTest
     {
         amount = bound(amount, 10000, DAI_ACCOUNT_AMOUNT);
-        vm.assume(token1 > 0 && token1 < creditManager.collateralTokensCount());
+        token1 = uint8(bound(token1, 1, creditManager.collateralTokensCount() - 1));
 
         tokenTestSuite.mint(Tokens.DAI, address(creditManager.pool()), type(uint96).max);
 
@@ -373,7 +373,7 @@ contract OpenCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFacad
 
         assertEq(creditAccount, expectedCreditAccount, "Incorrecct credit account address");
 
-        (uint256 debt, uint256 cumulativeIndexLastUpdate,,,,,,) = creditManager.creditAccountInfo(creditAccount);
+        (uint256 debt,,,,,,,) = creditManager.creditAccountInfo(creditAccount);
 
         assertEq(debt, 0, "Incorrect borrowed amount set in CA");
 

--- a/contracts/test/integration/credit/Quotas.int.t.sol
+++ b/contracts/test/integration/credit/Quotas.int.t.sol
@@ -376,8 +376,8 @@ contract QuotasIntegrationTest is IntegrationTestHelper, ICreditManagerV3Events 
         _addQuotedToken(tokenTestSuite.addressOf(Tokens.LINK), 10_00, uint96(100_000 * WAD));
         _addQuotedToken(tokenTestSuite.addressOf(Tokens.USDT), 500, uint96(100_000 * WAD));
 
-        vm.assume(quotaLink < type(uint96).max / 2);
-        vm.assume(quotaUsdt < type(uint96).max / 2);
+        quotaLink = uint96(bound(quotaLink, 0, uint96(type(int96).max)));
+        quotaUsdt = uint96(bound(quotaUsdt, 0, uint96(type(int96).max)));
 
         (address creditAccount,) = _openTestCreditAccount();
 

--- a/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
+++ b/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
@@ -63,10 +63,12 @@ contract AccountFactoryV3UnitTest is TestHelper, IAccountFactoryV3Events {
     }
 
     /// @notice U:[AF-2A]: `takeCreditAccount` works correctly when queue has no reusable accounts
-    function test_U_AF_02A_takeCreditAccount_works_correctly_when_queue_has_no_reusable_accounts(uint8 head, uint8 tail)
-        public
-    {
-        (head, tail) = head <= tail ? (head, tail) : (tail, head);
+    function test_U_AF_02A_takeCreditAccount_works_correctly_when_queue_has_no_reusable_accounts(
+        uint40 head,
+        uint40 tail
+    ) public {
+        tail = uint40(bound(tail, 0, 512));
+        head = uint40(bound(head, 0, tail));
         FactoryParams memory fp = accountFactory.factoryParams(creditManager);
         accountFactory.setFactoryParams(creditManager, fp.masterCreditAccount, head, tail);
         if (head < tail) {
@@ -92,11 +94,11 @@ contract AccountFactoryV3UnitTest is TestHelper, IAccountFactoryV3Events {
     /// @notice U:[AF-2B]: `takeCreditAccount` works correctly when queue has reusable accounts
     function test_U_AF_02B_takeCreditAccount_works_correctly_when_queue_has_reusable_accounts(
         address creditAccount,
-        uint8 head,
-        uint8 tail
+        uint40 head,
+        uint40 tail
     ) public {
-        vm.assume(head != tail);
-        (head, tail) = head < tail ? (head, tail) : (tail, head);
+        tail = uint40(bound(tail, 1, 512));
+        head = uint40(bound(head, 0, tail - 1));
 
         FactoryParams memory fp = accountFactory.factoryParams(creditManager);
         accountFactory.setFactoryParams(creditManager, fp.masterCreditAccount, head, tail);

--- a/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
+++ b/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
@@ -66,7 +66,7 @@ contract AccountFactoryV3UnitTest is TestHelper, IAccountFactoryV3Events {
     function test_U_AF_02A_takeCreditAccount_works_correctly_when_queue_has_no_reusable_accounts(uint8 head, uint8 tail)
         public
     {
-        vm.assume(head <= tail);
+        (head, tail) = head <= tail ? (head, tail) : (tail, head);
         FactoryParams memory fp = accountFactory.factoryParams(creditManager);
         accountFactory.setFactoryParams(creditManager, fp.masterCreditAccount, head, tail);
         if (head < tail) {
@@ -95,7 +95,8 @@ contract AccountFactoryV3UnitTest is TestHelper, IAccountFactoryV3Events {
         uint8 head,
         uint8 tail
     ) public {
-        vm.assume(head < tail);
+        vm.assume(head != tail);
+        (head, tail) = head < tail ? (head, tail) : (tail, head);
 
         FactoryParams memory fp = accountFactory.factoryParams(creditManager);
         accountFactory.setFactoryParams(creditManager, fp.masterCreditAccount, head, tail);

--- a/contracts/test/unit/core/PriceOracleV3.unit.t.sol
+++ b/contracts/test/unit/core/PriceOracleV3.unit.t.sol
@@ -45,9 +45,9 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
         bool skipCheck,
         uint8 decimals
     ) public {
-        vm.assume(updatedAt <= block.timestamp);
-        if (skipCheck) vm.assume(answer > 0);
-        vm.assume(decimals > 0 && decimals <= 18);
+        updatedAt = bound(updatedAt, 0, block.timestamp);
+        if (skipCheck) answer = bound(answer, 1, type(int256).max);
+        decimals = uint8(bound(decimals, 1, 18));
 
         address priceFeed = makeAddr("PRICE_FEED");
 

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -242,7 +242,8 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             t.mint(creditAccount, balance * ((i + 2) % 5));
 
             /// sets price between $0.01 and $60K
-            uint256 randomPrice = (uint256(keccak256(abi.encode(numberOfTokens, i, balance))) % 600_0000) * 10 ** 6;
+            uint256 randomPrice =
+                (uint256(keccak256(abi.encode(numberOfTokens, i, balance))) % (6000000 - 1) + 1) * 10 ** 6;
             priceOracleMock.setPrice(address(t), randomPrice);
         }
     }
@@ -1407,7 +1408,6 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
 
         amount = bound(amount, 1, 1e20 * WAD);
 
-        // uint256 amount = DAI_ACCOUNT_AMOUNT;
         address creditAccount = DUMB_ADDRESS;
         uint8 numberOfTokens = uint8(amount % 253);
 
@@ -1438,8 +1438,8 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         CollateralDebtData memory collateralDebtData =
             creditManager.calcDebtAndCollateralFC(creditAccount, CollateralCalcTask.DEBT_COLLATERAL);
 
-        /// @notice fuzzler could find a combination which enabled tokens with zero balances,
-        /// which cause to twvUSD == 0 and arithmetic errr later
+        /// @notice fuzzer could find a combination which enabled tokens with zero balances,
+        /// which causes twvUSD to be 0 and arithmetic error later
         vm.assume(collateralDebtData.twvUSD > 0);
 
         creditManager.setDebt(creditAccount, collateralDebtData.twvUSD + 1);
@@ -2378,9 +2378,6 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         ltFinal = uint16(bound(ltFinal, 0, PERCENTAGE_FACTOR));
 
         vm.assume(uint256(timestampRampStart) + uint256(rampDuration) < type(uint40).max);
-        // uint16 ltFinal = 2312;
-        // uint40 timestampRampStart = 1233;
-        // uint24 rampDuration = 33;
 
         uint256 snapshot = vm.snapshot();
 

--- a/contracts/test/unit/governance/PolicyManagerV3.unit.t.sol
+++ b/contracts/test/unit/governance/PolicyManagerV3.unit.t.sol
@@ -385,13 +385,10 @@ contract PolicyManagerV3UnitTest is Test {
         uint16 minPctChangeDown,
         uint16 minPctChangeUp
     ) public {
-        vm.assume(oldValue > 0);
-        vm.assume(newValue2 > 0);
-
-        vm.assume(oldValue < type(uint128).max);
-        vm.assume(newValue1 < type(uint128).max);
-        vm.assume(newValue2 < type(uint128).max);
-        vm.assume(newValue3 < type(uint128).max);
+        oldValue = bound(oldValue, 1, type(uint128).max);
+        newValue1 = bound(newValue1, 0, type(uint128).max);
+        newValue2 = bound(newValue2, 1, type(uint128).max);
+        newValue3 = bound(newValue3, 0, type(uint128).max);
 
         Policy memory policy = Policy({
             enabled: false,
@@ -460,13 +457,10 @@ contract PolicyManagerV3UnitTest is Test {
         uint16 maxPctChangeDown,
         uint16 maxPctChangeUp
     ) public {
-        vm.assume(oldValue > 0);
-        vm.assume(newValue2 > 0);
-
-        vm.assume(oldValue < type(uint128).max);
-        vm.assume(newValue1 < type(uint128).max);
-        vm.assume(newValue2 < type(uint128).max);
-        vm.assume(newValue3 < type(uint128).max);
+        oldValue = bound(oldValue, 1, type(uint128).max);
+        newValue1 = bound(newValue1, 0, type(uint128).max);
+        newValue2 = bound(newValue2, 1, type(uint128).max);
+        newValue3 = bound(newValue3, 0, type(uint128).max);
 
         Policy memory policy = Policy({
             enabled: false,

--- a/contracts/test/unit/libraries/BalancesLogic.unit.t.sol
+++ b/contracts/test/unit/libraries/BalancesLogic.unit.t.sol
@@ -48,7 +48,7 @@ contract BalancesLogicUnitTest is TestHelper {
         int128[16] calldata deltas,
         uint256 length
     ) public {
-        vm.assume(length <= 16);
+        length = bound(length, 0, 16);
 
         _setupTokenBalances(balances, length);
 
@@ -83,7 +83,7 @@ contract BalancesLogicUnitTest is TestHelper {
         uint256 length,
         bool greater
     ) public {
-        vm.assume(length <= 16);
+        length = bound(length, 0, 16);
 
         _setupTokenBalances(balances, length);
 
@@ -115,7 +115,7 @@ contract BalancesLogicUnitTest is TestHelper {
         uint128[16] calldata balances,
         uint256 tokensMask
     ) public {
-        tokensMask %= (2 ** 16);
+        tokensMask = bound(tokensMask, 0, type(uint16).max);
 
         _setupTokenBalances(balances, 16);
 
@@ -144,7 +144,7 @@ contract BalancesLogicUnitTest is TestHelper {
         uint256 tokensMask,
         bool greater
     ) public {
-        tokensMask %= (2 ** 16);
+        tokensMask = bound(tokensMask, 0, type(uint16).max);
 
         _setupTokenBalances(balancesBefore, 16);
 


### PR DESCRIPTION
* rely on `bound` instead of `vm.assume` for numeric variables to reduce the number of test rejects
* fix `creditManager.liquidateCreditAccount` fuzzing
* improve `CreditLogic` fuzzing