### PR TITLE
feat: `PriceOracleV3` improvements

### DIFF
--- a/contracts/core/PriceOracleV3.sol
+++ b/contracts/core/PriceOracleV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
@@ -32,7 +32,7 @@ import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
 ///         This logic is skipped if active price feed is trusted, in which case its answer is used.
 contract PriceOracleV3 is ACLNonReentrantTrait, PriceFeedValidationTrait, IPriceOracleV3 {
     /// @notice Contract version
-    uint256 public constant override version = 3_00;
+    uint256 public constant override version = 3_10;
 
     /// @dev Mapping from token address to price feed parameters
     mapping(address => PriceFeedParams) internal _priceFeedsParams;

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 // THIRD-PARTY
@@ -58,7 +58,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     using CreditAccountHelper for ICreditAccountBase;
 
     /// @notice Contract version
-    uint256 public constant override version = 3_01;
+    uint256 public constant override version = 3_10;
 
     /// @notice Address provider contract address
     address public immutable override addressProvider;
@@ -157,7 +157,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         underlying = IPoolV3(_pool).underlyingToken(); // U:[CM-1]
         _addToken(underlying); // U:[CM-1]
 
-        priceOracle = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_PRICE_ORACLE, 3_00); // U:[CM-1]
+        priceOracle = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_PRICE_ORACLE, 3_10); // U:[CM-1]
         accountFactory = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL); // U:[CM-1]
 
         creditConfigurator = msg.sender; // U:[CM-1]

--- a/contracts/interfaces/IPriceOracleV3.sol
+++ b/contracts/interfaces/IPriceOracleV3.sol
@@ -10,7 +10,7 @@ struct PriceFeedParams {
     uint32 stalenessPeriod;
     bool skipCheck;
     uint8 decimals;
-    bool useReserve;
+    bool active;
     bool trusted;
 }
 
@@ -21,7 +21,9 @@ interface IPriceOracleV3Events {
     );
 
     /// @notice Emitted when new reserve price feed is set for token
-    event SetReservePriceFeed(address indexed token, address indexed priceFeed, uint32 stalenessPeriod, bool skipCheck);
+    event SetReservePriceFeed(
+        address indexed token, address indexed priceFeed, uint32 stalenessPeriod, bool skipCheck, bool trusted
+    );
 
     /// @notice Emitted when new reserve price feed status is set for a token
     event SetReservePriceFeedStatus(address indexed token, bool active);
@@ -35,10 +37,9 @@ interface IPriceOracleV3 is IPriceOracleBase, IPriceOracleV3Events {
 
     function priceFeedsRaw(address token, bool reserve) external view returns (address);
 
-    function priceFeedParams(address token)
-        external
-        view
-        returns (address priceFeed, uint32 stalenessPeriod, bool skipCheck, uint8 decimals, bool trusted);
+    function priceFeedParams(address token) external view returns (PriceFeedParams memory);
+
+    function priceFeedParamsRaw(address token, bool reserve) external view returns (PriceFeedParams memory);
 
     function safeConvertToUSD(uint256 amount, address token) external view returns (uint256);
 
@@ -48,7 +49,7 @@ interface IPriceOracleV3 is IPriceOracleBase, IPriceOracleV3Events {
 
     function setPriceFeed(address token, address priceFeed, uint32 stalenessPeriod, bool trusted) external;
 
-    function setReservePriceFeed(address token, address priceFeed, uint32 stalenessPeriod) external;
+    function setReservePriceFeed(address token, address priceFeed, uint32 stalenessPeriod, bool trusted) external;
 
     function setReservePriceFeedStatus(address token, bool active) external;
 }

--- a/contracts/interfaces/IPriceOracleV3.sol
+++ b/contracts/interfaces/IPriceOracleV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import {IPriceOracleBase} from "@gearbox-protocol/core-v2/contracts/interfaces/IPriceOracleBase.sol";

--- a/contracts/interfaces/IPriceOracleV3.sol
+++ b/contracts/interfaces/IPriceOracleV3.sol
@@ -31,6 +31,8 @@ interface IPriceOracleV3Events {
 
 /// @title Price oracle V3 interface
 interface IPriceOracleV3 is IPriceOracleBase, IPriceOracleV3Events {
+    function getTokens() external view returns (address[] memory);
+
     function getPriceSafe(address token) external view returns (uint256);
 
     function getPriceRaw(address token, bool reserve) external view returns (uint256);

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -293,7 +293,7 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
     function _initCoreContracts() internal {
         cr = ContractsRegister(addressProvider.getAddressOrRevert(AP_CONTRACTS_REGISTER, NO_VERSION_CONTROL));
         accountFactory = AccountFactory(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL));
-        priceOracle = IPriceOracleV3(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
+        priceOracle = IPriceOracleV3(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_10));
         botList = BotListV3(payable(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_00)));
     }
 

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -917,7 +917,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
             vm.prank(CONFIGURATOR);
             creditConfigurator.setCreditFacade(address(cf), migrateSettings);
 
-            assertEq(address(creditManager.priceOracle()), addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
+            assertEq(address(creditManager.priceOracle()), addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_10));
 
             assertEq(address(creditManager.creditFacade()), address(cf));
             assertEq(address(creditConfigurator.creditFacade()), address(cf));

--- a/contracts/test/mocks/oracles/PriceOracleMock.sol
+++ b/contracts/test/mocks/oracles/PriceOracleMock.sol
@@ -15,7 +15,7 @@ import "forge-std/console.sol";
 contract PriceOracleMock is Test, IPriceOracleBase {
     mapping(address => uint256) public priceInUSD;
 
-    uint256 public constant override version = 3_00;
+    uint256 public constant override version = 3_10;
 
     mapping(address => bool) revertsOnGetPrice;
     mapping(address => mapping(bool => address)) priceFeedsInt;

--- a/contracts/test/unit/core/PriceOracleV3.unit.t.sol
+++ b/contracts/test/unit/core/PriceOracleV3.unit.t.sol
@@ -127,6 +127,7 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
         // setting the price feed
         // - must validate token and set decimals
         // - must set active status to true
+        // - must add token to the set
         vm.mockCall(token, abi.encodeCall(ERC20.decimals, ()), abi.encode(uint8(18)));
 
         vm.expectCall(token, abi.encodeCall(ERC20.decimals, ()));
@@ -145,6 +146,10 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
         assertEq(params.decimals, 18, "Incorrect decimals");
         assertEq(params.trusted, true, "Incorrect trusted");
         assertTrue(params.active, "active status not set to true when setting a price feed");
+
+        address[] memory tokens = priceOracle.getTokens();
+        assertEq(tokens.length, 1, "Incorrect number of tokens");
+        assertEq(tokens[0], token, "Incorrect token");
 
         // updating the price feed
         // - must not validate token

--- a/contracts/test/unit/core/PriceOracleV3.unit.t.sol
+++ b/contracts/test/unit/core/PriceOracleV3.unit.t.sol
@@ -12,7 +12,7 @@ import {IPriceOracleV3Events, PriceFeedParams} from "../../../interfaces/IPriceO
 import "../../../interfaces/IExceptions.sol";
 
 import {ERC20Mock} from "../../mocks/token/ERC20Mock.sol";
-import {PriceFeedMock, FlagState} from "../../mocks/oracles/PriceFeedMock.sol";
+import {PriceFeedMock} from "../../mocks/oracles/PriceFeedMock.sol";
 import {AddressProviderV3ACLMock} from "../../mocks/core/AddressProviderV3ACLMock.sol";
 
 import {PriceOracleV3Harness} from "./PriceOracleV3Harness.sol";
@@ -32,132 +32,289 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
         priceOracle = new PriceOracleV3Harness(address(ap));
     }
 
-    // ----------------------- //
-    // CORE INTERNAL FUNCTIONS //
-    // ----------------------- //
+    // -------------------- //
+    // CONVERSION FUNCTIONS //
+    // -------------------- //
 
-    /// @notice U:[PO-1]: `_getPrice` works as expected
-    function test_U_PO_01_getPrice_works_as_expected(
-        int256 answer,
-        uint256 updatedAt,
-        uint32 stalenessPeriod,
-        bool skipCheck,
-        uint8 decimals
-    ) public {
-        updatedAt = bound(updatedAt, 0, block.timestamp);
-        if (skipCheck) answer = bound(answer, 1, type(int256).max);
-        decimals = uint8(bound(decimals, 1, 18));
+    /// @notice U:[PO-1]: `getPrice` works as expected
+    function test_U_PO_01_getPrice_works_as_expected() public {
+        address token = address(new ERC20Mock("Test Token", "TEST", 18));
+        address mainFeed = address(new PriceFeedMock(2e8, 8));
+        address reserveFeed = address(new PriceFeedMock(1.8e8, 8));
 
-        address priceFeed = makeAddr("PRICE_FEED");
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        priceOracle.getPrice(token);
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        priceOracle.convertToUSD(2e18, token);
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        priceOracle.convertFromUSD(3.6e8, token);
 
-        vm.mockCall(
-            priceFeed,
-            abi.encodeCall(IPriceFeed.latestRoundData, ()),
-            abi.encode(uint80(0), answer, uint256(0), updatedAt, uint80(0))
-        );
+        vm.prank(configurator);
+        priceOracle.setPriceFeed(token, mainFeed, 3600, false);
+        assertEq(priceOracle.getPrice(token), 2e8);
+        assertEq(priceOracle.convertToUSD(2e18, token), 4e8);
+        assertEq(priceOracle.convertFromUSD(3.6e8, token), 1.8e18);
 
-        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()));
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeed(token, reserveFeed, 3600, false);
+        assertEq(priceOracle.getPrice(token), 2e8);
+        assertEq(priceOracle.convertToUSD(2e18, token), 4e8);
+        assertEq(priceOracle.convertFromUSD(3.6e8, token), 1.8e18);
 
-        bool mustRevert;
-        if (answer <= 0) {
-            vm.expectRevert(IncorrectPriceException.selector);
-            mustRevert = true;
-        } else if (!skipCheck && block.timestamp >= updatedAt + stalenessPeriod) {
-            vm.expectRevert(StalePriceException.selector);
-            mustRevert = true;
-        }
-
-        (uint256 price, uint256 scale) = priceOracle.getPrice(priceFeed, stalenessPeriod, skipCheck, decimals);
-
-        if (!mustRevert) {
-            assertEq(price, uint256(answer), "Incorrect price");
-            assertEq(scale, 10 ** decimals, "Incorrect scale");
-        }
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeedStatus(token, true);
+        assertEq(priceOracle.getPrice(token), 1.8e8);
+        assertEq(priceOracle.convertToUSD(2e18, token), 3.6e8);
+        assertEq(priceOracle.convertFromUSD(3.6e8, token), 2e18);
     }
 
-    /// @notice U:[PO-2]: `_getPriceFeedParams` works as expected
-    function test_U_PO_02_getPriceFeedParams_works_as_expected(address token, PriceFeedParams memory expectedParams)
-        public
-    {
-        priceOracle.hackPriceFeedParams(token, expectedParams);
+    /// @notice U:[PO-2]: `getPriceSafe` works as expected
+    function test_U_PO_02_getPriceSafe_works_as_expected() public {
+        address token = address(new ERC20Mock("Test Token", "TEST", 18));
+        address mainFeed = address(new PriceFeedMock(2e8, 8));
+        address reserveFeed = address(new PriceFeedMock(1.8e8, 8));
 
-        if (expectedParams.priceFeed == address(0)) {
-            vm.expectRevert(PriceFeedDoesNotExistException.selector);
-        }
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        priceOracle.getPriceSafe(token);
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        priceOracle.safeConvertToUSD(2e18, token);
 
-        PriceFeedParams memory params = priceOracle.getPriceFeedParams(token);
+        vm.prank(configurator);
+        priceOracle.setPriceFeed(token, mainFeed, 3600, true);
+        assertEq(priceOracle.getPriceSafe(token), 2e8);
+        assertEq(priceOracle.safeConvertToUSD(2e18, token), 4e8);
 
-        if (expectedParams.priceFeed == address(0)) return;
+        vm.prank(configurator);
+        priceOracle.setPriceFeed(token, mainFeed, 3600, false);
+        assertEq(priceOracle.getPriceSafe(token), 0);
+        assertEq(priceOracle.safeConvertToUSD(2e18, token), 0);
 
-        assertEq(params.priceFeed, expectedParams.priceFeed, "Incorrect priceFeed");
-        assertEq(params.stalenessPeriod, expectedParams.stalenessPeriod, "Incorrect stalenessPeriod");
-        assertEq(params.decimals, expectedParams.decimals, "Incorrect decimals");
-        assertEq(params.skipCheck, expectedParams.skipCheck, "Incorrect skipCheck");
-        assertEq(params.useReserve, expectedParams.useReserve, "Incorrect useReserve");
-        assertEq(params.trusted, expectedParams.trusted, "Incorrect trusted");
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeed(token, reserveFeed, 3600, true);
+        assertEq(priceOracle.getPriceSafe(token), 1.8e8);
+        assertEq(priceOracle.safeConvertToUSD(2e18, token), 3.6e8);
+
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeedStatus(token, true);
+        assertEq(priceOracle.getPriceSafe(token), 1.8e8);
+        assertEq(priceOracle.safeConvertToUSD(2e18, token), 3.6e8);
+
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeed(token, reserveFeed, 3600, false);
+        assertEq(priceOracle.getPriceSafe(token), 0);
+        assertEq(priceOracle.safeConvertToUSD(2e18, token), 0);
     }
 
-    /// @notice U:[PO-3]: `_getTokenReserveKey` works as expected
-    /// forge-config: default.fuzz.runs = 5000
-    function test_U_PO_03_getTokenReserveKey_works_as_expected(address token) public {
+    // ----------------------- //
+    // CONFIGURATION FUNCTIONS //
+    // ----------------------- //
+
+    /// @notice U:[PO-3]: `setPriceFeed` works as expected
+    function test_U_PO_03_setPriceFeed_works_as_expected() public {
+        address token = makeAddr("TOKEN");
+        address priceFeed = address(new PriceFeedMock(42, 8));
+
+        // revert cases
+        vm.expectRevert(ZeroAddressException.selector);
+        priceOracle.setPriceFeed(address(0), priceFeed, 0, false);
+
+        vm.expectRevert(ZeroAddressException.selector);
+        priceOracle.setPriceFeed(token, address(0), 0, false);
+
+        vm.expectRevert(CallerNotConfiguratorException.selector);
+        priceOracle.setPriceFeed(token, priceFeed, 0, false);
+
+        // setting the price feed
+        // - must validate token and set decimals
+        // - must set active status to true
+        vm.mockCall(token, abi.encodeCall(ERC20.decimals, ()), abi.encode(uint8(18)));
+
+        vm.expectCall(token, abi.encodeCall(ERC20.decimals, ()));
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.skipPriceCheck, ()));
+
+        vm.expectEmit(true, true, true, true);
+        emit SetPriceFeed(token, priceFeed, 3600, false, true);
+
+        vm.prank(configurator);
+        priceOracle.setPriceFeed(token, priceFeed, 3600, true);
+
+        PriceFeedParams memory params = priceOracle.priceFeedParamsRaw(token, false);
+        assertEq(params.priceFeed, priceFeed, "Incorrect priceFeed");
+        assertEq(params.stalenessPeriod, 3600, "Incorrect stalenessPeriod");
+        assertEq(params.skipCheck, false, "Incorrect skipCheck");
+        assertEq(params.decimals, 18, "Incorrect decimals");
+        assertEq(params.trusted, true, "Incorrect trusted");
+        assertTrue(params.active, "active status not set to true when setting a price feed");
+
+        // updating the price feed
+        // - must not validate token
+        // - must not change active status
+        params.active = false;
+        priceOracle.hackPriceFeedParams(token, params);
+        vm.mockCallRevert(token, abi.encodeCall(ERC20.decimals, ()), "should not be called");
+
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.skipPriceCheck, ()));
+
+        vm.expectEmit(true, true, true, true);
+        emit SetPriceFeed(token, priceFeed, 3600, false, true);
+
+        vm.prank(configurator);
+        priceOracle.setPriceFeed(token, priceFeed, 3600, true);
+
+        params = priceOracle.priceFeedParamsRaw(token, false);
+        assertEq(params.priceFeed, priceFeed, "Incorrect priceFeed");
+        assertEq(params.stalenessPeriod, 3600, "Incorrect stalenessPeriod");
+        assertEq(params.skipCheck, false, "Incorrect skipCheck");
+        assertEq(params.decimals, 18, "Incorrect decimals");
+        assertEq(params.trusted, true, "Incorrect trusted");
+        assertFalse(params.active, "active status changed when updating a price feed");
+    }
+
+    /// @notice U:[PO-4]: `setReservePriceFeed` works as expected
+    function test_U_PO_04_setReservePriceFeed_works_as_expected() public {
+        address token = makeAddr("TOKEN");
+        address mainFeed = makeAddr("MAIN_FEED");
+        address reserveFeed = address(new PriceFeedMock(42, 8));
+
+        // revert cases
+        vm.expectRevert(ZeroAddressException.selector);
+        priceOracle.setPriceFeed(address(0), reserveFeed, 0, false);
+
+        vm.expectRevert(ZeroAddressException.selector);
+        priceOracle.setPriceFeed(token, address(0), 0, false);
+
+        vm.expectRevert(CallerNotConfiguratorException.selector);
+        priceOracle.setPriceFeed(token, reserveFeed, 0, false);
+
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeed(token, reserveFeed, 0, false);
+
+        // setting the reserve price feed
+        // - must copy decimals from main feed
+        // - must invert main feed active status
+        priceOracle.hackPriceFeedParams(token, PriceFeedParams(mainFeed, 0, false, 18, false, false));
+
+        vm.expectCall(reserveFeed, abi.encodeCall(IPriceFeed.skipPriceCheck, ()));
+
+        vm.expectEmit(true, true, true, true);
+        emit SetReservePriceFeed(token, reserveFeed, 3600, false, true);
+
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeed(token, reserveFeed, 3600, true);
+
+        PriceFeedParams memory params = priceOracle.priceFeedParamsRaw(token, true);
+        assertEq(params.priceFeed, reserveFeed, "Incorrect priceFeed");
+        assertEq(params.stalenessPeriod, 3600, "Incorrect stalenessPeriod");
+        assertEq(params.skipCheck, false, "Incorrect skipCheck");
+        assertEq(params.decimals, 18, "Incorrect decimals");
+        assertEq(params.trusted, true, "Incorrect trusted");
+        assertTrue(params.active, "active status is not negative of main feed active status");
+    }
+
+    /// @notice U:[PO-5]: `setReservePriceFeedStatus` works as expected
+    function test_U_PO_05_setReservePriceFeedStatus_works_as_expected() public {
+        address token = makeAddr("TOKEN");
+        address mainFeed = makeAddr("MAIN_FEED");
+        address reserveFeed = makeAddr("RESERVE_FEED");
+
+        vm.expectRevert(CallerNotControllerException.selector);
+        priceOracle.setReservePriceFeedStatus(token, true);
+
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeedStatus(token, true);
+
+        priceOracle.hackPriceFeedParams(token, PriceFeedParams(mainFeed, 0, false, 18, false, true));
+        priceOracle.hackReservePriceFeedParams(token, PriceFeedParams(reserveFeed, 0, false, 18, false, false));
+
+        // activating reserve feed
+        vm.expectEmit(true, true, true, true);
+        emit SetReservePriceFeedStatus(token, true);
+
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeedStatus(token, true);
+
+        assertFalse(priceOracle.priceFeedParamsRaw(token, false).active, "Main feed is unexpectedly active");
+        assertTrue(priceOracle.priceFeedParamsRaw(token, true).active, "Reserve feed is unexpectedly inactive");
+        assertEq(priceOracle.priceFeeds(token), reserveFeed, "Incorrect priceFeeds");
+
+        // activating main feed
+        vm.expectEmit(true, true, true, true);
+        emit SetReservePriceFeedStatus(token, false);
+
+        vm.prank(configurator);
+        priceOracle.setReservePriceFeedStatus(token, false);
+
+        assertTrue(priceOracle.priceFeedParamsRaw(token, false).active, "Main feed is unexpectedly inactive");
+        assertFalse(priceOracle.priceFeedParamsRaw(token, true).active, "Reserve feed is unexpectedly active");
+        assertEq(priceOracle.priceFeeds(token), mainFeed, "Incorrect priceFeeds");
+    }
+
+    // ------------------ //
+    // INTERNAL FUNCTIONS //
+    // ------------------ //
+
+    /// @notice U:[PO-6]: `_getTokenReserveKey` works as expected
+    function test_U_PO_06_getTokenReserveKey_works_as_expected(address token) public {
         address expectedKey = address(uint160(uint256(keccak256(abi.encodePacked("RESERVE", token)))));
-        assertEq(priceOracle.getTokenReserveKey(token), expectedKey);
+        assertEq(priceOracle.exposed_getTokenReserveKey(token), expectedKey);
     }
 
-    /// @notice U:[PO-4]: `_validateToken` works as expected
-    function test_U_PO_04_validateToken_works_as_expected() public {
+    /// @notice U:[PO-7]: `_validateToken` works as expected
+    function test_U_PO_07_validateToken_works_as_expected() public {
         address token = makeAddr("TOKEN");
 
         vm.etch(token, "");
         vm.expectRevert(abi.encodeWithSelector(AddressIsNotContractException.selector, token));
-        priceOracle.validateToken(token);
+        priceOracle.exposed_validateToken(token);
 
         vm.etch(token, "CODE");
 
         vm.mockCallRevert(token, abi.encodeCall(ERC20.decimals, ()), "");
         vm.expectRevert(IncorrectTokenContractException.selector);
-        priceOracle.validateToken(token);
+        priceOracle.exposed_validateToken(token);
 
         vm.mockCall(token, abi.encodeCall(ERC20.decimals, ()), abi.encode(uint8(0)));
         vm.expectRevert(IncorrectTokenContractException.selector);
-        priceOracle.validateToken(token);
+        priceOracle.exposed_validateToken(token);
 
         vm.mockCall(token, abi.encodeCall(ERC20.decimals, ()), abi.encode(uint8(19)));
         vm.expectRevert(IncorrectTokenContractException.selector);
-        priceOracle.validateToken(token);
+        priceOracle.exposed_validateToken(token);
 
         vm.mockCall(token, abi.encodeCall(ERC20.decimals, ()), abi.encode(uint8(6)));
-        uint8 decimals = priceOracle.validateToken(token);
+        uint8 decimals = priceOracle.exposed_validateToken(token);
         assertEq(decimals, 6, "Incorrect decimals");
     }
 
-    /// @notice U:[PO-5]: `_validatePriceFeed` works as expected
-    function test_U_PO_05_validatePriceFeed_works_as_expected() public {
+    /// @notice U:[PO-8]: `_validatePriceFeed` works as expected
+    function test_U_PO_08_validatePriceFeed_works_as_expected() public {
         address priceFeed = makeAddr("PRICE_FEED");
 
         // not a contract
         vm.etch(priceFeed, "");
         vm.expectRevert(abi.encodeWithSelector(AddressIsNotContractException.selector, priceFeed));
-        priceOracle.validatePriceFeed(priceFeed, 0);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 0);
 
         vm.etch(priceFeed, "CODE");
 
         // does not implement `decimals()`
         vm.mockCallRevert(priceFeed, abi.encodeCall(IPriceFeed.decimals, ()), "");
         vm.expectRevert(IncorrectPriceFeedException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 0);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 0);
 
         // wrong decimals
         vm.mockCall(priceFeed, abi.encodeCall(IPriceFeed.decimals, ()), abi.encode(uint8(6)));
         vm.expectRevert(IncorrectPriceFeedException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 0);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 0);
 
         vm.mockCall(priceFeed, abi.encodeCall(IPriceFeed.decimals, ()), abi.encode(uint8(8)));
 
         // does not implement `latestRoundData()`
         vm.mockCallRevert(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()), "");
         vm.expectRevert(IncorrectPriceFeedException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 0);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 0);
 
         // zero staleness period while shipCheck = false
         vm.mockCall(
@@ -166,7 +323,7 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
             abi.encode(uint80(0), int256(42), uint256(0), block.timestamp, uint80(0))
         );
         vm.expectRevert(IncorrectParameterException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 0);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 0);
 
         // negative price
         vm.mockCall(
@@ -175,7 +332,7 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
             abi.encode(uint80(0), int256(-1), uint256(0), block.timestamp, uint80(0))
         );
         vm.expectRevert(IncorrectPriceException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 3600);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 3600);
 
         // stale price
         vm.mockCall(
@@ -184,184 +341,63 @@ contract PriceOracleV3UnitTest is Test, IPriceOracleV3Events {
             abi.encode(uint80(0), int256(42), uint256(0), block.timestamp - 7200, uint80(0))
         );
         vm.expectRevert(StalePriceException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 3600);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 3600);
 
         // staleness check is skipped for updatable feed
         vm.mockCall(priceFeed, abi.encodeCall(IUpdatablePriceFeed.updatable, ()), abi.encode(true));
-        bool skipCheck = priceOracle.validatePriceFeed(priceFeed, 3600);
+        bool skipCheck = priceOracle.exposed_validatePriceFeed(priceFeed, 3600);
         assertFalse(skipCheck, "skipCheck is unexpectedly true");
 
         // non-zero staleness period while skipCheck = true
         vm.mockCall(priceFeed, abi.encodeCall(IPriceFeed.skipPriceCheck, ()), abi.encode(true));
         vm.expectRevert(IncorrectParameterException.selector);
-        priceOracle.validatePriceFeed(priceFeed, 3600);
+        priceOracle.exposed_validatePriceFeed(priceFeed, 3600);
 
-        skipCheck = priceOracle.validatePriceFeed(priceFeed, 0);
+        skipCheck = priceOracle.exposed_validatePriceFeed(priceFeed, 0);
         assertTrue(skipCheck, "skipCheck is unexpectedly false");
     }
 
-    // ----------------------- //
-    // CONFIGURATION FUNCTIONS //
-    // ----------------------- //
+    /// @notice U:[PO-9]: `_getValidatedPrice` works as expected
+    function test_U_PO_09_getValidatedPrice_works_as_expected() public {
+        address priceFeed = makeAddr("PRICE_FEED");
+        uint256 stalenessPeriod = 20;
 
-    /// @notice U:[PO-6]: `setPriceFeed` works as expected
-    function test_U_PO_06_setPriceFeed_works_as_expected() public {
-        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 18);
-        PriceFeedMock priceFeed = new PriceFeedMock(42, 8);
-
-        vm.expectRevert(ZeroAddressException.selector);
-        priceOracle.setPriceFeed(address(0), address(priceFeed), 0, false);
-
-        vm.expectRevert(ZeroAddressException.selector);
-        priceOracle.setPriceFeed(address(token), address(0), 0, false);
-
-        vm.expectRevert(CallerNotConfiguratorException.selector);
-        priceOracle.setPriceFeed(address(token), address(priceFeed), 0, false);
-
-        vm.expectEmit(true, true, false, true);
-        emit SetPriceFeed(address(token), address(priceFeed), 3600, false, false);
-
-        vm.prank(configurator);
-        priceOracle.setPriceFeed(address(token), address(priceFeed), 3600, false);
-        PriceFeedParams memory params = priceOracle.getPriceFeedParams(address(token));
-        assertEq(params.priceFeed, address(priceFeed), "Incorrect priceFeed");
-        assertEq(params.decimals, 18, "Incorrect decimals");
-        assertEq(params.skipCheck, false, "Incorrect skipCheck");
-        assertEq(params.stalenessPeriod, 3600, "Incorrect stalenessPeriod");
-        assertEq(params.useReserve, false, "Incorrect useReserve");
-    }
-
-    /// @notice U:[PO-7]: `setReservePriceFeed` works as expected
-    function test_U_PO_07_setReservePriceFeed_works_as_expected() public {
-        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 18);
-        PriceFeedMock priceFeed = new PriceFeedMock(42, 8);
-
-        vm.expectRevert(ZeroAddressException.selector);
-        priceOracle.setPriceFeed(address(0), address(priceFeed), 0, false);
-
-        vm.expectRevert(ZeroAddressException.selector);
-        priceOracle.setPriceFeed(address(token), address(0), 0, false);
-
-        vm.expectRevert(CallerNotConfiguratorException.selector);
-        priceOracle.setPriceFeed(address(token), address(priceFeed), 0, false);
-
-        vm.expectRevert(PriceFeedDoesNotExistException.selector);
-        vm.prank(configurator);
-        priceOracle.setReservePriceFeed(address(token), address(priceFeed), 0);
-
-        priceOracle.hackPriceFeedParams(address(token), PriceFeedParams(address(0), 0, false, 18, false, false));
-        priceFeed.setSkipPriceCheck(FlagState.TRUE);
-
-        vm.expectEmit(true, true, false, true);
-        emit SetReservePriceFeed(address(token), address(priceFeed), 0, true);
-
-        vm.prank(configurator);
-        priceOracle.setReservePriceFeed(address(token), address(priceFeed), 0);
-
-        PriceFeedParams memory params = priceOracle.getReservePriceFeedParams(address(token));
-        assertEq(params.priceFeed, address(priceFeed), "Incorrect priceFeed");
-        assertEq(params.decimals, 18, "Incorrect decimals");
-        assertEq(params.skipCheck, true, "Incorrect skipCheck");
-        assertEq(params.stalenessPeriod, 0, "Incorrect stalenessPeriod");
-        assertEq(params.useReserve, false, "Incorrect useReserve");
-    }
-
-    /// @notice U:[PO-8]: `setReservePriceFeedStatus` works as expected
-    function test_U_PO_08_setReservePriceFeedStatus_works_as_expected() public {
-        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 18);
-        PriceFeedMock priceFeed = new PriceFeedMock(42, 8);
-
-        vm.expectRevert(CallerNotControllerException.selector);
-        priceOracle.setReservePriceFeedStatus(address(token), true);
-
-        vm.expectRevert(PriceFeedDoesNotExistException.selector);
-        vm.prank(configurator);
-        priceOracle.setReservePriceFeedStatus(address(token), true);
-
-        priceOracle.hackPriceFeedParams(
-            address(token), PriceFeedParams(makeAddr("MAIN_PRICE_FEED"), 0, false, 18, false, false)
+        // returns answer if `skipCheck` is true
+        vm.mockCall(
+            priceFeed,
+            abi.encodeCall(IPriceFeed.latestRoundData, ()),
+            abi.encode(uint80(0), -123, uint256(0), block.timestamp - stalenessPeriod - 1, uint80(0))
         );
-        priceOracle.hackReservePriceFeedParams(
-            address(token), PriceFeedParams(address(priceFeed), 0, false, 18, false, false)
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()));
+        assertEq(priceOracle.exposed_getValidatedPrice(priceFeed, 20, true), -123, "Incorrect price");
+
+        // reverts on negative price if `skipCheck` is false
+        vm.mockCall(
+            priceFeed,
+            abi.encodeCall(IPriceFeed.latestRoundData, ()),
+            abi.encode(uint80(0), -123, uint256(0), block.timestamp - stalenessPeriod + 1, uint80(0))
         );
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()));
+        vm.expectRevert(IncorrectPriceException.selector);
+        priceOracle.exposed_getValidatedPrice(priceFeed, 20, false);
 
-        vm.expectEmit(true, false, false, true);
-        emit SetReservePriceFeedStatus(address(token), true);
-
-        vm.prank(configurator);
-        priceOracle.setReservePriceFeedStatus(address(token), true);
-
-        assertTrue(priceOracle.getPriceFeedParams(address(token)).useReserve, "useReserve is unexpectedly false");
-        // make sure all functions now switch to reserve price feed
-        assertEq(priceOracle.priceFeeds(address(token)), address(priceFeed), "Incorrect priceFeed");
-    }
-
-    // -------------------- //
-    // CONVERSION FUNCTIONS //
-    // -------------------- //
-
-    /// @notice U:[PO-9]: `convertToUSD` works as expected
-    function test_U_PO_09_covnertToUSD_and_convertFromUSD_work_as_expected() public {
-        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 6);
-        PriceFeedMock priceFeed = new PriceFeedMock(2e8, 8);
-        priceOracle.hackPriceFeedParams(address(token), PriceFeedParams(address(priceFeed), 0, false, 6, false, false));
-
-        assertEq(priceOracle.convertToUSD(100e6, address(token)), 200e8, "Incorrect convertToUSD");
-        assertEq(priceOracle.convertFromUSD(1000e8, address(token)), 500e6, "Incorrect convertFromUSD");
-    }
-
-    /// @notice U:[PO-10]: `convert` works as epxected
-    function test_U_PO_10_convert_works_as_expected() public {
-        ERC20Mock token1 = new ERC20Mock("Test Token 1", "TEST1", 6);
-        PriceFeedMock priceFeed1 = new PriceFeedMock(10e8, 8);
-        priceOracle.hackPriceFeedParams(
-            address(token1), PriceFeedParams(address(priceFeed1), 0, false, 6, false, false)
+        // reverts on stale price if `skipCheck` is false
+        vm.mockCall(
+            priceFeed,
+            abi.encodeCall(IPriceFeed.latestRoundData, ()),
+            abi.encode(uint80(0), 123, uint256(0), block.timestamp - stalenessPeriod - 1, uint80(0))
         );
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()));
+        vm.expectRevert(StalePriceException.selector);
+        priceOracle.exposed_getValidatedPrice(priceFeed, 20, false);
 
-        ERC20Mock token2 = new ERC20Mock("Test Token 2", "TEST2", 18);
-        PriceFeedMock priceFeed2 = new PriceFeedMock(0.1e8, 8);
-        priceOracle.hackPriceFeedParams(
-            address(token2), PriceFeedParams(address(priceFeed2), 0, false, 18, false, false)
+        // returns answer if `skipCheck` is false
+        vm.mockCall(
+            priceFeed,
+            abi.encodeCall(IPriceFeed.latestRoundData, ()),
+            abi.encode(uint80(0), 123, uint256(0), block.timestamp - stalenessPeriod + 1, uint80(0))
         );
-
-        assertEq(
-            priceOracle.convert(1e6, address(token1), address(token2)), 100e18, "Incorrect token1 -> token2 conversion"
-        );
-
-        assertEq(
-            priceOracle.convert(100e18, address(token2), address(token1)), 1e6, "Incorrect token2 -> token1 conversion"
-        );
-    }
-
-    /// @notice U:[PO-11]: Safe conversion works as expected
-    function test_U_PO_11_safe_conversion_works_as_expected() public {
-        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 6);
-        PriceFeedMock mainFeed = new PriceFeedMock(2e8, 8);
-        PriceFeedMock reserveFeed = new PriceFeedMock(1.8e8, 8);
-
-        // untrusted feed without reserve feed
-        priceOracle.hackPriceFeedParams(address(token), PriceFeedParams(address(mainFeed), 0, false, 6, false, false));
-        assertEq(priceOracle.getPriceSafe(address(token)), 0, "getPriceSafe, untrusted feed without reserve feed");
-        assertEq(
-            priceOracle.safeConvertToUSD(100e6, address(token)),
-            0,
-            "safeConvertToUSD untrusted feed without reserve feed"
-        );
-
-        // untrusted feed with reserve feed
-        priceOracle.hackReservePriceFeedParams(
-            address(token), PriceFeedParams(address(reserveFeed), 0, false, 6, false, false)
-        );
-        assertEq(priceOracle.getPriceSafe(address(token)), 1.8e8, "safe price of untrusted feed with reserve feed");
-        assertEq(
-            priceOracle.safeConvertToUSD(100e6, address(token)),
-            180e8,
-            "safeConvertToUSD untrusted feed with reserve feed"
-        );
-
-        // trusted feed
-        priceOracle.hackPriceFeedParams(address(token), PriceFeedParams(address(mainFeed), 0, false, 6, false, true));
-        assertEq(priceOracle.getPriceSafe(address(token)), 2e8, "safe price of trusted feed");
-        assertEq(priceOracle.safeConvertToUSD(100e6, address(token)), 200e8, "safeConvertToUSD trusted feed");
+        vm.expectCall(priceFeed, abi.encodeCall(IPriceFeed.latestRoundData, ()));
+        assertEq(priceOracle.exposed_getValidatedPrice(priceFeed, 20, false), 123, "Incorrect price");
     }
 }

--- a/contracts/test/unit/core/PriceOracleV3Harness.sol
+++ b/contracts/test/unit/core/PriceOracleV3Harness.sol
@@ -8,30 +8,6 @@ import {PriceOracleV3, PriceFeedParams} from "../../../core/PriceOracleV3.sol";
 contract PriceOracleV3Harness is PriceOracleV3 {
     constructor(address addressProvider) PriceOracleV3(addressProvider) {}
 
-    function getTokenReserveKey(address token) external pure returns (address) {
-        return _getTokenReserveKey(token);
-    }
-
-    function getPriceFeedParams(address token) external view returns (PriceFeedParams memory) {
-        (address priceFeed, uint32 stalenessPeriod, bool skipCheck, uint8 decimals, bool useReserve, bool trusted) =
-            _getPriceFeedParams(token);
-        return PriceFeedParams(priceFeed, stalenessPeriod, skipCheck, decimals, useReserve, trusted);
-    }
-
-    function getReservePriceFeedParams(address token) external view returns (PriceFeedParams memory) {
-        (address priceFeed, uint32 stalenessPeriod, bool skipCheck, uint8 decimals, bool useReserve, bool trusted) =
-            _getPriceFeedParams(_getTokenReserveKey(token));
-        return PriceFeedParams(priceFeed, stalenessPeriod, skipCheck, decimals, useReserve, trusted);
-    }
-
-    function getPrice(address priceFeed, uint32 stalenessPeriod, bool skipCheck, uint8 decimals)
-        external
-        view
-        returns (uint256 price, uint256 scale)
-    {
-        return _getPrice(priceFeed, stalenessPeriod, skipCheck, decimals);
-    }
-
     function hackPriceFeedParams(address token, PriceFeedParams memory params) external {
         _priceFeedsParams[token] = params;
     }
@@ -40,11 +16,27 @@ contract PriceOracleV3Harness is PriceOracleV3 {
         _priceFeedsParams[_getTokenReserveKey(token)] = params;
     }
 
-    function validateToken(address token) external view returns (uint8 decimals) {
+    function exposed_getTokenReserveKey(address token) external pure returns (address) {
+        return _getTokenReserveKey(token);
+    }
+
+    function exposed_validateToken(address token) external view returns (uint8 decimals) {
         return _validateToken(token);
     }
 
-    function validatePriceFeed(address priceFeed, uint32 stalenessPeriod) external view returns (bool skipCheck) {
+    function exposed_validatePriceFeed(address priceFeed, uint32 stalenessPeriod)
+        external
+        view
+        returns (bool skipCheck)
+    {
         return _validatePriceFeed(priceFeed, stalenessPeriod);
+    }
+
+    function exposed_getValidatedPrice(address priceFeed, uint32 stalenessPeriod, bool skipCheck)
+        external
+        view
+        returns (int256 answer)
+    {
+        return _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
     }
 }

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -131,7 +131,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
 
         botListMock = BotListMock(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_00));
 
-        priceOracleMock = PriceOracleMock(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
+        priceOracleMock = PriceOracleMock(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_10));
 
         AddressProviderV3ACLMock(address(addressProvider)).addPausableAdmin(CONFIGURATOR);
 

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -120,7 +120,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
 
         accountFactory = AccountFactoryMock(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL));
 
-        priceOracleMock = PriceOracleMock(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
+        priceOracleMock = PriceOracleMock(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_10));
 
         /// Inits all state
         isFeeToken = false;
@@ -315,7 +315,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
 
         assertEq(
             address(creditManager.priceOracle()),
-            addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00),
+            addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_10),
             _testCaseErr("Incorrect Price oracle")
         );
 

--- a/contracts/traits/PriceFeedValidationTrait.sol
+++ b/contracts/traits/PriceFeedValidationTrait.sol
@@ -21,8 +21,8 @@ abstract contract PriceFeedValidationTrait {
 
     /// @dev Ensures that price is positive and not stale
     function _checkAnswer(int256 price, uint256 updatedAt, uint32 stalenessPeriod) internal view {
-        if (price <= 0) revert IncorrectPriceException();
-        if (block.timestamp >= updatedAt + stalenessPeriod) revert StalePriceException();
+        if (price <= 0) revert IncorrectPriceException(); // U:[PO-9]
+        if (block.timestamp >= updatedAt + stalenessPeriod) revert StalePriceException(); // U:[PO-9]
     }
 
     /// @dev Valites that `priceFeed` is a contract that adheres to Chainlink interface and passes sanity checks
@@ -30,33 +30,33 @@ abstract contract PriceFeedValidationTrait {
     ///      issues during deployment and configuration, so for such price feeds staleness check is skipped, and
     ///      special care must be taken to ensure all parameters are in tune.
     function _validatePriceFeed(address priceFeed, uint32 stalenessPeriod) internal view returns (bool skipCheck) {
-        if (!priceFeed.isContract()) revert AddressIsNotContractException(priceFeed); // U:[PO-5]
+        if (!priceFeed.isContract()) revert AddressIsNotContractException(priceFeed); // U:[PO-8]
 
         try IPriceFeed(priceFeed).decimals() returns (uint8 _decimals) {
-            if (_decimals != 8) revert IncorrectPriceFeedException(); // U:[PO-5]
+            if (_decimals != 8) revert IncorrectPriceFeedException(); // U:[PO-8]
         } catch {
-            revert IncorrectPriceFeedException(); // U:[PO-5]
+            revert IncorrectPriceFeedException(); // U:[PO-8]
         }
 
         try IPriceFeed(priceFeed).skipPriceCheck() returns (bool _skipCheck) {
-            skipCheck = _skipCheck; // U:[PO-5]
+            skipCheck = _skipCheck; // U:[PO-8]
         } catch {}
 
         try IPriceFeed(priceFeed).latestRoundData() returns (uint80, int256 answer, uint256, uint256 updatedAt, uint80)
         {
             if (skipCheck) {
-                if (stalenessPeriod != 0) revert IncorrectParameterException(); // U:[PO-5]
+                if (stalenessPeriod != 0) revert IncorrectParameterException(); // U:[PO-8]
             } else {
-                if (stalenessPeriod == 0) revert IncorrectParameterException(); // U:[PO-5]
+                if (stalenessPeriod == 0) revert IncorrectParameterException(); // U:[PO-8]
 
                 bool updatable;
                 try IUpdatablePriceFeed(priceFeed).updatable() returns (bool _updatable) {
                     updatable = _updatable;
                 } catch {}
-                if (!updatable) _checkAnswer(answer, updatedAt, stalenessPeriod); // U:[PO-5]
+                if (!updatable) _checkAnswer(answer, updatedAt, stalenessPeriod); // U:[PO-8]
             }
         } catch {
-            revert IncorrectPriceFeedException(); // U:[PO-5]
+            revert IncorrectPriceFeedException(); // U:[PO-8]
         }
     }
 
@@ -67,7 +67,7 @@ abstract contract PriceFeedValidationTrait {
         returns (int256 answer)
     {
         uint256 updatedAt;
-        (, answer,, updatedAt,) = IPriceFeed(priceFeed).latestRoundData(); // U:[PO-1]
-        if (!skipCheck) _checkAnswer(answer, updatedAt, stalenessPeriod); // U:[PO-1]
+        (, answer,, updatedAt,) = IPriceFeed(priceFeed).latestRoundData(); // U:[PO-9]
+        if (!skipCheck) _checkAnswer(answer, updatedAt, stalenessPeriod); // U:[PO-9]
     }
 }


### PR DESCRIPTION
Price oracle is made more robust and consistent:
* add `getTokens` that returns all tokens with price feeds
* add missing getter`priceFeedsParamsRaw`
* `trusted` is now an attribute of price feed, not token
* `getPriceSafe` is reworked to be more efficient and, well, safe
* `setPriceFeed` no longer deactivates reserve price feed

Note: `priceFeeds` and `priceFeedsParams` no longer revert if price feed for token is not set, instead they simply return zero values.  