### PR TITLE
fix: `CreditConfiguratorV3` improvements

### DIFF
--- a/contracts/interfaces/ICreditConfiguratorV3.sol
+++ b/contracts/interfaces/ICreditConfiguratorV3.sol
@@ -10,25 +10,15 @@ enum AllowanceAction {
     ALLOW
 }
 
-/// @notice Struct with collateral token parameters
-/// @param token Token address
-/// @param liquidationThreshold Liquidation threshold in bps
-struct CollateralToken {
-    address token;
-    uint16 liquidationThreshold;
-}
-
 /// @notice Struct with credit manager configuration parameters
 /// @param minDebt Minimum debt amount per account
 /// @param maxDebt Maximum debt amount per account
-/// @param collateralTokens Array of collateral tokens
 /// @param degenNFT Whether to apply Degen NFT whitelist logic
 /// @param expirable Whether facade must be expirable
 /// @param name Credit manager name
 struct CreditManagerOpts {
     uint128 minDebt;
     uint128 maxDebt;
-    CollateralToken[] collateralTokens;
     address degenNFT;
     bool expirable;
     string name;

--- a/contracts/test/config/ConfigManager.sol
+++ b/contracts/test/config/ConfigManager.sol
@@ -3,7 +3,7 @@
 // (c) Gearbox Foundation, 2023
 pragma solidity ^0.8.17;
 
-import {CollateralToken, IPoolV3DeployConfig, CollateralTokenHuman} from "../interfaces/ICreditConfig.sol";
+import {IPoolV3DeployConfig, CollateralTokenHuman} from "../interfaces/ICreditConfig.sol";
 
 contract ConfigManager {
     error ConfigNotFound(string id);

--- a/contracts/test/config/MockCreditConfig.sol
+++ b/contracts/test/config/MockCreditConfig.sol
@@ -9,7 +9,7 @@ import {Tokens} from "@gearbox-protocol/sdk-gov/contracts/Tokens.sol";
 import {NetworkDetector} from "@gearbox-protocol/sdk-gov/contracts/NetworkDetector.sol";
 import {Contracts} from "@gearbox-protocol/sdk-gov/contracts/SupportedContracts.sol";
 import "forge-std/console.sol";
-import {CreditManagerOpts, CollateralToken} from "../../credit/CreditConfiguratorV3.sol";
+import {CreditManagerOpts} from "../../credit/CreditConfiguratorV3.sol";
 
 import {
     LinearIRMV3DeployParams,
@@ -17,7 +17,6 @@ import {
     CreditManagerV3DeployParams,
     GaugeRate,
     PoolQuotaLimit,
-    CollateralToken,
     IPoolV3DeployConfig,
     CollateralTokenHuman
 } from "../interfaces/ICreditConfig.sol";

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -25,7 +25,7 @@ import {ICreditFacadeV3Multicall} from "../../interfaces/ICreditFacadeV3.sol";
 
 import {CreditManagerV3} from "../../credit/CreditManagerV3.sol";
 import {IPriceOracleV3} from "../../interfaces/IPriceOracleV3.sol";
-import {CreditManagerOpts, CollateralToken} from "../../credit/CreditConfiguratorV3.sol";
+import {CreditManagerOpts} from "../../credit/CreditConfiguratorV3.sol";
 import {PoolFactory} from "../suites/PoolFactory.sol";
 
 import {TokensTestSuite} from "../suites/TokensTestSuite.sol";
@@ -419,7 +419,6 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
             CreditManagerOpts memory cmOpts = CreditManagerOpts({
                 minDebt: cmParams.minDebt,
                 maxDebt: cmParams.maxDebt,
-                collateralTokens: new CollateralToken[](0), //_convertCollateral(cmParams.collateralTokens),
                 degenNFT: (whitelisted) ? address(degenNFT) : address(0),
                 expirable: (anyExpirable) ? cmParams.expirable : expirable,
                 name: cmParams.name
@@ -679,19 +678,6 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
 
     function executeOneLineMulticall(address creditAccount, address target, bytes memory callData) internal {
         creditFacade.multicall(creditAccount, MultiCallBuilder.build(MultiCall({target: target, callData: callData})));
-    }
-
-    function _convertCollateral(CollateralTokenHuman[] memory clts)
-        internal
-        view
-        returns (CollateralToken[] memory result)
-    {
-        uint256 len = clts.length;
-        result = new CollateralToken[](len);
-        for (uint256 i = 0; i < len; i++) {
-            result[i] =
-                CollateralToken({token: tokenTestSuite.addressOf(clts[i].token), liquidationThreshold: clts[i].lt});
-        }
     }
 
     function _addCollateralTokens(CollateralTokenHuman[] memory clts) internal {

--- a/contracts/test/interfaces/ICreditConfig.sol
+++ b/contracts/test/interfaces/ICreditConfig.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.17;
 import {Tokens} from "@gearbox-protocol/sdk-gov/contracts/Tokens.sol";
 
 import {ITokenTestSuite} from "./ITokenTestSuite.sol";
-import {CreditManagerOpts, CollateralToken} from "../../interfaces/ICreditConfiguratorV3.sol";
+import {CreditManagerOpts} from "../../interfaces/ICreditConfiguratorV3.sol";
 import {Contracts} from "@gearbox-protocol/sdk-gov/contracts/SupportedContracts.sol";
 
 struct PriceFeedConfig {


### PR DESCRIPTION
* bump `version` to `3_01`
* `constructor` no longer adds collateral tokens
* `CreditManagerOpts` no longer stores tokens to be added on deployment
* `addCollateralToken` no longer checks token's price in the oracle