### PR TITLE
feat: `BotListV3` improvements

### DIFF
--- a/contracts/core/BotListV3.sol
+++ b/contracts/core/BotListV3.sol
@@ -62,7 +62,7 @@ contract BotListV3 is ACLNonReentrantTrait, ContractsRegisterTrait, IBotListV3 {
         return _activeBots[creditManager][creditAccount].values();
     }
 
-    /// @notice Returns `bot`'s permissions for `creditAccount` in its credit manager`, including information
+    /// @notice Returns `bot`'s permissions for `creditAccount` in its credit manager, including information
     ///         on whether bot is forbidden or has special permissions in the credit manager
     function getBotStatus(address bot, address creditAccount)
         external

--- a/contracts/core/BotListV3.sol
+++ b/contracts/core/BotListV3.sol
@@ -88,6 +88,7 @@ contract BotListV3 is ACLNonReentrantTrait, ContractsRegisterTrait, IBotListV3 {
     /// @dev Reverts if `creditAccount`'s credit manager is not approved or caller is not a facade connected to it
     /// @dev Reverts if trying to set non-zero permissions that don't meet bot's requirements
     /// @dev Reverts if trying to set non-zero permissions for a forbidden bot or for a bot with special permissions
+    /// @custom:tests U:[BL-1]
     function setBotPermissions(address bot, address creditAccount, uint192 permissions)
         external
         override
@@ -118,6 +119,7 @@ contract BotListV3 is ACLNonReentrantTrait, ContractsRegisterTrait, IBotListV3 {
 
     /// @notice Removes all bots' permissions for `creditAccount` in its credit manager
     /// @dev Reverts if `creditAccount`'s credit manager is not approved or caller is not a facade connected to it
+    /// @custom:tests U:[BL-2]
     function eraseAllBotPermissions(address creditAccount) external override {
         address creditManager = ICreditAccountBase(creditAccount).creditManager();
         _revertIfCallerNotValidCreditFacade(creditManager);
@@ -164,6 +166,7 @@ contract BotListV3 is ACLNonReentrantTrait, ContractsRegisterTrait, IBotListV3 {
     /// @notice Sets `bot`'s special permissions in `creditManager` to `permissions`
     /// @dev Reverts if trying to set non-zero permissions that don't meet bot's requirements
     /// @dev Reverts if trying to set non-zero permissions for a forbidden bot
+    /// @custom:tests U:[BL-3]
     function setBotSpecialPermissions(address bot, address creditManager, uint192 permissions)
         external
         override

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -370,8 +370,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     }
 
     /// @notice Executes a batch of calls allowing bot to manage a credit account
-    ///         - Performs a multicall (allowed calls are determined by permissions given by account's owner
-    ///           or by DAO in case bot has special permissions in the credit manager)
+    ///         - Performs a multicall (allowed calls are determined by permissions given by account's owner)
     ///         - Runs the collateral check
     /// @param creditAccount Account to perform the calls on
     /// @param calls List of calls to perform
@@ -387,13 +386,10 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     {
         _getBorrowerOrRevert(creditAccount); // U:[FA-5]
 
-        (uint256 botPermissions, bool forbidden, bool hasSpecialPermissions) =
+        (uint256 botPermissions, bool forbidden) =
             IBotListV3(botList).getBotStatus({bot: msg.sender, creditAccount: creditAccount});
 
-        if (
-            botPermissions == 0 || forbidden
-                || (!hasSpecialPermissions && (_flagsOf(creditAccount) & BOT_PERMISSIONS_SET_FLAG == 0))
-        ) {
+        if (forbidden || botPermissions == 0 || _flagsOf(creditAccount) & BOT_PERMISSIONS_SET_FLAG == 0) {
             revert NotApprovedBotException(); // U:[FA-19]
         }
 

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 // THIRD-PARTY
@@ -72,7 +72,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     using SafeERC20 for IERC20;
 
     /// @notice Contract version
-    uint256 public constant override version = 3_01;
+    uint256 public constant override version = 3_10;
 
     /// @notice Maximum quota size, as a multiple of `maxDebt`
     uint256 public constant override maxQuotaMultiplier = 2;
@@ -157,7 +157,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
 
         address addressProvider = ICreditManagerV3(_creditManager).addressProvider();
         weth = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_WETH_TOKEN, NO_VERSION_CONTROL); // U:[FA-1]
-        botList = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_BOT_LIST, 3_00); // U:[FA-1]
+        botList = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_BOT_LIST, 3_10); // U:[FA-1]
 
         degenNFT = _degenNFT; // U:[FA-1]
 
@@ -255,7 +255,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
         if (enabledTokensMask != 0) revert CloseAccountWithEnabledTokensException(); // U:[FA-11]
 
         if (_flagsOf(creditAccount) & BOT_PERMISSIONS_SET_FLAG != 0) {
-            IBotListV3(botList).eraseAllBotPermissions(creditManager, creditAccount); // U:[FA-11]
+            IBotListV3(botList).eraseAllBotPermissions(creditAccount); // U:[FA-11]
         }
 
         ICreditManagerV3(creditManager).closeCreditAccount(creditAccount); // U:[FA-11]
@@ -387,11 +387,8 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     {
         _getBorrowerOrRevert(creditAccount); // U:[FA-5]
 
-        (uint256 botPermissions, bool forbidden, bool hasSpecialPermissions) = IBotListV3(botList).getBotStatus({
-            bot: msg.sender,
-            creditManager: creditManager,
-            creditAccount: creditAccount
-        });
+        (uint256 botPermissions, bool forbidden, bool hasSpecialPermissions) =
+            IBotListV3(botList).getBotStatus({bot: msg.sender, creditAccount: creditAccount});
 
         if (
             botPermissions == 0 || forbidden
@@ -419,12 +416,8 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     {
         if (permissions & ~ALL_PERMISSIONS != 0) revert UnexpectedPermissionsException(); // U:[FA-41]
 
-        uint256 remainingBots = IBotListV3(botList).setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: permissions
-        }); // U:[FA-41]
+        uint256 remainingBots =
+            IBotListV3(botList).setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: permissions}); // U:[FA-41]
 
         if (remainingBots == 0) {
             _setFlagFor({creditAccount: creditAccount, flag: BOT_PERMISSIONS_SET_FLAG, value: false}); // U:[FA-41]

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -405,7 +405,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     /// @param bot Bot to set permissions for
     /// @param permissions A bit mask encoding bot permissions
     /// @dev Reverts if `creditAccount` is not opened in connected credit manager by caller
-    /// @dev Reverts if `permissions` has unexpected bits enabled
+    /// @dev Reverts if `permissions` has unexpected bits enabled or some bits required by `bot` disabled
     /// @dev Reverts if account has more active bots than allowed after changing permissions
     /// @dev Changes account's `BOT_PERMISSIONS_SET_FLAG` in the credit manager if needed
     function setBotPermissions(address creditAccount, address bot, uint192 permissions)

--- a/contracts/interfaces/IBotListV3.sol
+++ b/contracts/interfaces/IBotListV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import {IVersion} from "@gearbox-protocol/core-v2/contracts/interfaces/IVersion.sol";
@@ -48,23 +48,20 @@ interface IBotListV3 is IBotListV3Events, IVersion {
     // PERMISSIONS //
     // ----------- //
 
-    function botPermissions(address bot, address creditManager, address creditAccount)
-        external
-        view
-        returns (uint192);
+    function botPermissions(address bot, address creditAccount) external view returns (uint192);
 
-    function activeBots(address creditManager, address creditAccount) external view returns (address[] memory);
+    function activeBots(address creditAccount) external view returns (address[] memory);
 
-    function getBotStatus(address bot, address creditManager, address creditAccount)
+    function getBotStatus(address bot, address creditAccount)
         external
         view
         returns (uint192 permissions, bool forbidden, bool hasSpecialPermissions);
 
-    function setBotPermissions(address bot, address creditManager, address creditAccount, uint192 permissions)
+    function setBotPermissions(address bot, address creditAccount, uint192 permissions)
         external
         returns (uint256 activeBotsRemaining);
 
-    function eraseAllBotPermissions(address creditManager, address creditAccount) external;
+    function eraseAllBotPermissions(address creditAccount) external;
 
     // ------------- //
     // CONFIGURATION //

--- a/contracts/interfaces/IBotListV3.sol
+++ b/contracts/interfaces/IBotListV3.sol
@@ -20,13 +20,10 @@ interface IBotListV3Events {
     // PERMISSIONS //
     // ----------- //
 
-    /// @notice Emitted when new `bot`'s permissions and funding params are set for `creditAccount` in `creditManager`
+    /// @notice Emitted when new `bot`'s permissions are set for `creditAccount` in `creditManager`
     event SetBotPermissions(
         address indexed bot, address indexed creditManager, address indexed creditAccount, uint192 permissions
     );
-
-    /// @notice Emitted when `bot`'s permissions and funding params are removed for `creditAccount` in `creditManager`
-    event EraseBot(address indexed bot, address indexed creditManager, address indexed creditAccount);
 
     // ------------- //
     // CONFIGURATION //

--- a/contracts/interfaces/IBotListV3.sol
+++ b/contracts/interfaces/IBotListV3.sol
@@ -68,6 +68,8 @@ interface IBotListV3 is IBotListV3Events, IVersion {
 
     function botSpecialPermissions(address bot, address creditManager) external view returns (uint192);
 
+    function specialBots(address creditManager) external view returns (address[] memory);
+
     function approvedCreditManager(address creditManager) external view returns (bool);
 
     function setBotForbiddenStatus(address bot, bool forbidden) external;

--- a/contracts/interfaces/IBotListV3.sol
+++ b/contracts/interfaces/IBotListV3.sol
@@ -7,11 +7,9 @@ import {IVersion} from "@gearbox-protocol/core-v2/contracts/interfaces/IVersion.
 
 /// @notice Bot info
 /// @param forbidden Whether bot is forbidden
-/// @param specialPermissions Mapping credit manager => bot's special permissions
 /// @param permissions Mapping credit manager => credit account => bot's permissions
 struct BotInfo {
     bool forbidden;
-    mapping(address => uint192) specialPermissions;
     mapping(address => mapping(address => uint192)) permissions;
 }
 
@@ -32,9 +30,6 @@ interface IBotListV3Events {
     /// @notice Emitted when `bot`'s forbidden status is set
     event SetBotForbiddenStatus(address indexed bot, bool forbidden);
 
-    /// @notice Emitted when `bot`'s special permissions in `creditManager` are set
-    event SetBotSpecialPermissions(address indexed bot, address indexed creditManager, uint192 permissions);
-
     /// @notice Emitted when `creditManager`'s approved status is set
     event SetCreditManagerApprovedStatus(address indexed creditManager, bool approved);
 }
@@ -52,7 +47,7 @@ interface IBotListV3 is IBotListV3Events, IVersion {
     function getBotStatus(address bot, address creditAccount)
         external
         view
-        returns (uint192 permissions, bool forbidden, bool hasSpecialPermissions);
+        returns (uint192 permissions, bool forbidden);
 
     function setBotPermissions(address bot, address creditAccount, uint192 permissions)
         external
@@ -66,15 +61,9 @@ interface IBotListV3 is IBotListV3Events, IVersion {
 
     function botForbiddenStatus(address bot) external view returns (bool);
 
-    function botSpecialPermissions(address bot, address creditManager) external view returns (uint192);
-
-    function specialBots(address creditManager) external view returns (address[] memory);
-
     function approvedCreditManager(address creditManager) external view returns (bool);
 
     function setBotForbiddenStatus(address bot, bool forbidden) external;
-
-    function setBotSpecialPermissions(address bot, address creditManager, uint192 permissions) external;
 
     function setCreditManagerApprovedStatus(address creditManager, bool approved) external;
 }

--- a/contracts/interfaces/IBotV3.sol
+++ b/contracts/interfaces/IBotV3.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.17;
+
+/// @title Bot V3 interface
+/// @notice Minimal interface contracts must conform to in order to be used as bots in Gearbox V3
+interface IBotV3 {
+    /// @notice Mask of permissions required for bot operation, see `ICreditFacadeV3Multicall`
+    function requiredPermissions() external view returns (uint192);
+}

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 // ------- //
@@ -288,6 +288,9 @@ error ParameterChangedAfterQueuedTxException();
 
 /// @notice Thrown when attempting to set non-zero permissions for a forbidden or special bot
 error InvalidBotException();
+
+/// @notice Thrown when attempting to set permissions for the bot that don't meet its requirements
+error InsufficientBotPermissionsException();
 
 // --------------- //
 // ACCOUNT FACTORY //

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -286,10 +286,10 @@ error ParameterChangedAfterQueuedTxException();
 // BOT LIST //
 // -------- //
 
-/// @notice Thrown when attempting to set non-zero permissions for a forbidden or special bot
+/// @notice Thrown when attempting to set non-zero permissions for a forbidden bot
 error InvalidBotException();
 
-/// @notice Thrown when attempting to set permissions for the bot that don't meet its requirements
+/// @notice Thrown when attempting to set permissions for a bot that don't meet its requirements
 error InsufficientBotPermissionsException();
 
 // --------------- //

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -294,7 +294,7 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
         cr = ContractsRegister(addressProvider.getAddressOrRevert(AP_CONTRACTS_REGISTER, NO_VERSION_CONTROL));
         accountFactory = AccountFactory(addressProvider.getAddressOrRevert(AP_ACCOUNT_FACTORY, NO_VERSION_CONTROL));
         priceOracle = IPriceOracleV3(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
-        botList = BotListV3(payable(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_00)));
+        botList = BotListV3(payable(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_10)));
     }
 
     function _attachPool(address _pool) internal returns (bool isCompartible) {

--- a/contracts/test/integration/credit/Bots.int.sol
+++ b/contracts/test/integration/credit/Bots.int.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import {CreditManagerV3} from "../../../credit/CreditManagerV3.sol";
@@ -34,9 +34,8 @@ import "../../lib/constants.sol";
 import "../../../interfaces/IExceptions.sol";
 
 // MOCKS
-import {AdapterMock} from "../../mocks//core/AdapterMock.sol";
-
-import {GeneralMock} from "../../mocks//GeneralMock.sol";
+import {AdapterMock} from "../../mocks/core/AdapterMock.sol";
+import {BotMock} from "../../mocks/core/BotMock.sol";
 
 // SUITES
 
@@ -51,7 +50,7 @@ contract BotsIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Events {
     function test_I_BOT_01_botMulticall_works_correctly() public withAdapterMock creditTest {
         (address creditAccount,) = _openTestCreditAccount();
 
-        address bot = address(new GeneralMock());
+        address bot = address(new BotMock());
 
         bytes memory DUMB_CALLDATA = adapterMock.dumbCallData();
 
@@ -120,7 +119,7 @@ contract BotsIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Events {
     function test_I_BOT_02_setBotPermissions_works_correctly() public creditTest {
         (address creditAccount,) = _openTestCreditAccount();
 
-        address bot = address(new GeneralMock());
+        address bot = address(new BotMock());
 
         vm.expectRevert(CallerNotCreditAccountOwnerException.selector);
         vm.prank(FRIEND);

--- a/contracts/test/integration/credit/Bots.int.sol
+++ b/contracts/test/integration/credit/Bots.int.sol
@@ -66,13 +66,6 @@ contract BotsIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Events {
             MultiCall({target: address(adapterMock), callData: abi.encodeCall(AdapterMock.dumbCall, (0, 0))})
         );
 
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(address(bot), address(creditManager), type(uint192).max);
-        vm.prank(bot);
-        creditFacade.botMulticall(creditAccount, calls);
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(address(bot), address(creditManager), 0);
-
         vm.prank(USER);
         creditFacade.setBotPermissions(creditAccount, bot, uint192(ALL_PERMISSIONS));
 

--- a/contracts/test/integration/credit/Bots.int.sol
+++ b/contracts/test/integration/credit/Bots.int.sol
@@ -56,7 +56,7 @@ contract BotsIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Events {
         bytes memory DUMB_CALLDATA = adapterMock.dumbCallData();
 
         vm.prank(address(creditFacade));
-        botList.setBotPermissions(bot, address(creditManager), creditAccount, uint192(ALL_PERMISSIONS));
+        botList.setBotPermissions(bot, creditAccount, uint192(ALL_PERMISSIONS));
 
         vm.expectRevert(NotApprovedBotException.selector);
         creditFacade.botMulticall(
@@ -77,7 +77,7 @@ contract BotsIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Events {
         vm.prank(USER);
         creditFacade.setBotPermissions(creditAccount, bot, uint192(ALL_PERMISSIONS));
 
-        botList.getBotStatus({creditManager: address(creditManager), creditAccount: creditAccount, bot: bot});
+        botList.getBotStatus({creditAccount: creditAccount, bot: bot});
 
         vm.expectEmit(true, true, false, true);
         emit StartMultiCall({creditAccount: creditAccount, caller: bot});

--- a/contracts/test/integration/credit/CloseCreditAccount.int.sol
+++ b/contracts/test/integration/credit/CloseCreditAccount.int.sol
@@ -193,9 +193,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
         vm.expectEmit(false, false, false, true);
         emit FinishMultiCall();
 
-        vm.expectCall(
-            address(botList), abi.encodeCall(BotListV3.eraseAllBotPermissions, (address(creditManager), creditAccount))
-        );
+        vm.expectCall(address(botList), abi.encodeCall(BotListV3.eraseAllBotPermissions, (creditAccount)));
 
         vm.expectEmit(true, true, false, false);
         emit CloseCreditAccount(creditAccount, USER);

--- a/contracts/test/integration/credit/CloseCreditAccount.int.sol
+++ b/contracts/test/integration/credit/CloseCreditAccount.int.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import "../../../interfaces/IAddressProviderV3.sol";
@@ -39,7 +39,7 @@ import "../../../interfaces/IExceptions.sol";
 // MOCKS
 import {AdapterMock} from "../../mocks/core/AdapterMock.sol";
 import {PriceFeedMock} from "../../mocks/oracles/PriceFeedMock.sol";
-import {GeneralMock} from "../../mocks/GeneralMock.sol";
+import {BotMock} from "../../mocks/core/BotMock.sol";
 
 // SUITES
 
@@ -163,7 +163,7 @@ contract CloseCreditAccountIntegrationTest is IntegrationTestHelper, ICreditFaca
             MultiCall({target: address(adapterMock), callData: abi.encodeCall(AdapterMock.dumbCall, (0, 0))})
         );
 
-        address bot = address(new GeneralMock());
+        address bot = address(new BotMock());
 
         vm.prank(USER);
         creditFacade.setBotPermissions({

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -969,7 +969,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
 
             assertEq(
                 botList2,
-                migrateSettings ? botList : addressProvider.getAddressOrRevert(AP_BOT_LIST, 300),
+                migrateSettings ? botList : addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_10),
                 "Bot list was not transferred"
             );
 

--- a/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
+++ b/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
-import {BotListV3} from "../../../core/BotListV3.sol";
 import {ICreditAccountBase} from "../../../interfaces/ICreditAccountV3.sol";
-import {
-    ICreditManagerV3,
-    ICreditManagerV3Events,
-    ManageDebtAction,
-    BOT_PERMISSIONS_SET_FLAG
-} from "../../../interfaces/ICreditManagerV3.sol";
+import {ICreditManagerV3, ICreditManagerV3Events, ManageDebtAction} from "../../../interfaces/ICreditManagerV3.sol";
 
 import "../../../interfaces/ICreditFacadeV3.sol";
 import {MultiCallBuilder} from "../../lib/MultiCallBuilder.sol";
@@ -52,13 +46,6 @@ contract LiquidateCreditAccountIntegrationTest is IntegrationTestHelper, ICredit
         (address creditAccount,) = _openTestCreditAccount();
 
         bytes memory DUMB_CALLDATA = adapterMock.dumbCallData();
-
-        vm.prank(USER);
-        creditFacade.setBotPermissions({
-            creditAccount: creditAccount,
-            bot: address(adapterMock),
-            permissions: uint192(ADD_COLLATERAL_PERMISSION)
-        });
 
         MultiCall[] memory calls = MultiCallBuilder.build(
             MultiCall({target: address(adapterMock), callData: abi.encodeCall(AdapterMock.dumbCall, (0, 0))})

--- a/contracts/test/mocks/core/AddressProviderV3ACLMock.sol
+++ b/contracts/test/mocks/core/AddressProviderV3ACLMock.sol
@@ -34,7 +34,7 @@ contract AddressProviderV3ACLMock is Test, AddressProviderV3 {
         _setAddress(AP_ACCOUNT_FACTORY, address(accountFactoryMock), NO_VERSION_CONTROL);
 
         BotListMock botListMock = new BotListMock();
-        _setAddress(AP_BOT_LIST, address(botListMock), 3_00);
+        _setAddress(AP_BOT_LIST, address(botListMock), 3_10);
 
         _setAddress(AP_CONTRACTS_REGISTER, address(this), 0);
 

--- a/contracts/test/mocks/core/BotListMock.sol
+++ b/contracts/test/mocks/core/BotListMock.sol
@@ -8,24 +8,17 @@ contract BotListMock {
 
     uint256 return_botPermissions;
     bool return_forbidden;
-    bool return_hasSpecialPermissions;
 
     uint256 return_activeBotsRemaining;
 
-    function setBotStatusReturns(uint256 botPermissions, bool forbidden, bool hasSpecialPermissions) external {
+    function setBotStatusReturns(uint256 botPermissions, bool forbidden) external {
         return_botPermissions = botPermissions;
         return_forbidden = forbidden;
-        return_hasSpecialPermissions = hasSpecialPermissions;
     }
 
-    function getBotStatus(address, address)
-        external
-        view
-        returns (uint256 botPermissions, bool forbidden, bool hasSpecialPermissions)
-    {
+    function getBotStatus(address, address) external view returns (uint256 botPermissions, bool forbidden) {
         botPermissions = return_botPermissions;
         forbidden = return_forbidden;
-        hasSpecialPermissions = return_hasSpecialPermissions;
     }
 
     function eraseAllBotPermissions(address) external view {

--- a/contracts/test/mocks/core/BotListMock.sol
+++ b/contracts/test/mocks/core/BotListMock.sol
@@ -18,7 +18,7 @@ contract BotListMock {
         return_hasSpecialPermissions = hasSpecialPermissions;
     }
 
-    function getBotStatus(address, address, address)
+    function getBotStatus(address, address)
         external
         view
         returns (uint256 botPermissions, bool forbidden, bool hasSpecialPermissions)
@@ -28,7 +28,7 @@ contract BotListMock {
         hasSpecialPermissions = return_hasSpecialPermissions;
     }
 
-    function eraseAllBotPermissions(address, address) external view {
+    function eraseAllBotPermissions(address) external view {
         if (revertOnErase) {
             revert("Unexpected call to eraseAllBotPermissions");
         }
@@ -42,11 +42,7 @@ contract BotListMock {
         return_activeBotsRemaining = activeBotsRemaining;
     }
 
-    function setBotPermissions(address, address, address, uint192)
-        external
-        view
-        returns (uint256 activeBotsRemaining)
-    {
+    function setBotPermissions(address, address, uint192) external view returns (uint256 activeBotsRemaining) {
         activeBotsRemaining = return_activeBotsRemaining;
     }
 }

--- a/contracts/test/mocks/core/BotMock.sol
+++ b/contracts/test/mocks/core/BotMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.17;
+
+import {IBotV3} from "../../../interfaces/IBotV3.sol";
+
+contract BotMock is IBotV3 {
+    uint192 public override requiredPermissions;
+
+    function setRequiredPermissions(uint192 permissions) external {
+        requiredPermissions = permissions;
+    }
+}

--- a/contracts/test/unit/core/BotListV3.unit.t.sol
+++ b/contracts/test/unit/core/BotListV3.unit.t.sol
@@ -75,16 +75,6 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         vm.prank(CONFIGURATOR);
         botList.setBotForbiddenStatus(bot, false);
 
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(bot, creditManager, 1);
-
-        vm.expectRevert(InvalidBotException.selector);
-        vm.prank(creditFacade);
-        botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: type(uint192).max});
-
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(bot, creditManager, 0);
-
         vm.expectEmit(true, true, true, true);
         emit SetBotPermissions(bot, creditManager, creditAccount, 1);
 
@@ -154,31 +144,5 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
 
         address[] memory activeBots = botList.activeBots(creditAccount);
         assertEq(activeBots.length, 0, "Not all active bots were disabled");
-    }
-
-    /// @dev U:[BL-3]: `setBotSpecialPermissions` works correctly
-    function test_U_BL_03_setBotSpecialPermissions_works_correctly() public {
-        vm.expectRevert(CallerNotConfiguratorException.selector);
-        botList.setBotSpecialPermissions(bot, creditManager, 2);
-
-        BotMock(bot).setRequiredPermissions(1);
-        vm.expectRevert(InsufficientBotPermissionsException.selector);
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(bot, creditManager, 2);
-        BotMock(bot).setRequiredPermissions(2);
-
-        vm.expectEmit(true, true, false, true);
-        emit SetBotSpecialPermissions(bot, creditManager, 2);
-
-        vm.prank(CONFIGURATOR);
-        botList.setBotSpecialPermissions(bot, creditManager, 2);
-
-        (uint192 permissions,, bool hasSpecialPermissions) = botList.getBotStatus(bot, creditAccount);
-        address[] memory specialBots = botList.specialBots(creditManager);
-
-        assertEq(permissions, 2, "Special permissions are incorrect");
-        assertTrue(hasSpecialPermissions, "Special permissions status returned incorrectly");
-        assertEq(specialBots.length, 1, "Incorrect list of special bots");
-        assertEq(specialBots[0], bot, "Incorrect list of special bots");
     }
 }

--- a/contracts/test/unit/core/BotListV3.unit.t.sol
+++ b/contracts/test/unit/core/BotListV3.unit.t.sol
@@ -56,33 +56,18 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
     function test_U_BL_01_setBotPermissions_works_correctly() public {
         vm.expectRevert(CallerNotCreditFacadeException.selector);
         vm.prank(invalidFacade);
-        botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: type(uint192).max
-        });
+        botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: type(uint192).max});
 
         vm.expectRevert(abi.encodeWithSelector(AddressIsNotContractException.selector, DUMB_ADDRESS));
         vm.prank(creditFacade);
-        botList.setBotPermissions({
-            bot: DUMB_ADDRESS,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: type(uint192).max
-        });
+        botList.setBotPermissions({bot: DUMB_ADDRESS, creditAccount: creditAccount, permissions: type(uint192).max});
 
         vm.prank(CONFIGURATOR);
         botList.setBotForbiddenStatus(bot, true);
 
         vm.expectRevert(InvalidBotException.selector);
         vm.prank(creditFacade);
-        botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: type(uint192).max
-        });
+        botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: type(uint192).max});
 
         vm.prank(CONFIGURATOR);
         botList.setBotForbiddenStatus(bot, false);
@@ -92,12 +77,7 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
 
         vm.expectRevert(InvalidBotException.selector);
         vm.prank(creditFacade);
-        botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: type(uint192).max
-        });
+        botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: type(uint192).max});
 
         vm.prank(CONFIGURATOR);
         botList.setBotSpecialPermissions(bot, creditManager, 0);
@@ -106,32 +86,23 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         emit SetBotPermissions(bot, creditManager, creditAccount, 1);
 
         vm.prank(creditFacade);
-        uint256 activeBotsRemaining = botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: 1
-        });
+        uint256 activeBotsRemaining =
+            botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: 1});
 
         assertEq(activeBotsRemaining, 1, "Incorrect number of bots returned");
-        assertEq(botList.botPermissions(bot, creditManager, creditAccount), 1, "Bot permissions were not set");
+        assertEq(botList.botPermissions(bot, creditAccount), 1, "Bot permissions were not set");
 
-        address[] memory bots = botList.activeBots(creditManager, creditAccount);
+        address[] memory bots = botList.activeBots(creditAccount);
         assertEq(bots.length, 1, "Incorrect active bots array length");
         assertEq(bots[0], bot, "Incorrect address added to active bots list");
 
         vm.prank(creditFacade);
-        activeBotsRemaining = botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: 2
-        });
+        activeBotsRemaining = botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: 2});
 
         assertEq(activeBotsRemaining, 1, "Incorrect number of bots returned");
-        assertEq(botList.botPermissions(bot, creditManager, creditAccount), 2, "Bot permissions were not set");
+        assertEq(botList.botPermissions(bot, creditAccount), 2, "Bot permissions were not set");
 
-        bots = botList.activeBots(creditManager, creditAccount);
+        bots = botList.activeBots(creditAccount);
         assertEq(bots.length, 1, "Incorrect active bots array length");
         assertEq(bots[0], bot, "Incorrect address added to active bots list");
 
@@ -142,38 +113,29 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         emit EraseBot(bot, creditManager, creditAccount);
 
         vm.prank(creditFacade);
-        activeBotsRemaining = botList.setBotPermissions({
-            bot: bot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: 0
-        });
+        activeBotsRemaining = botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: 0});
 
         assertEq(activeBotsRemaining, 0, "Incorrect number of bots returned");
-        assertEq(botList.botPermissions(bot, creditManager, creditAccount), 0, "Bot permissions were not set");
+        assertEq(botList.botPermissions(bot, creditAccount), 0, "Bot permissions were not set");
 
-        bots = botList.activeBots(creditManager, creditAccount);
+        bots = botList.activeBots(creditAccount);
         assertEq(bots.length, 0, "Incorrect active bots array length");
     }
 
     /// @dev U:[BL-2]: `eraseAllBotPermissions` works correctly
     function test_U_BL_02_eraseAllBotPermissions_works_correctly() public {
         vm.prank(creditFacade);
-        botList.setBotPermissions({bot: bot, creditManager: creditManager, creditAccount: creditAccount, permissions: 1});
+        botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: 1});
 
         vm.prank(creditFacade);
-        uint256 activeBotsRemaining = botList.setBotPermissions({
-            bot: otherBot,
-            creditManager: creditManager,
-            creditAccount: creditAccount,
-            permissions: 2
-        });
+        uint256 activeBotsRemaining =
+            botList.setBotPermissions({bot: otherBot, creditAccount: creditAccount, permissions: 2});
 
         assertEq(activeBotsRemaining, 2, "Incorrect number of active bots");
 
         vm.expectRevert(CallerNotCreditFacadeException.selector);
         vm.prank(invalidFacade);
-        botList.eraseAllBotPermissions(creditManager, creditAccount);
+        botList.eraseAllBotPermissions(creditAccount);
 
         vm.expectEmit(true, true, true, false);
         emit EraseBot(otherBot, creditManager, creditAccount);
@@ -182,12 +144,12 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         emit EraseBot(bot, creditManager, creditAccount);
 
         vm.prank(creditFacade);
-        botList.eraseAllBotPermissions(creditManager, creditAccount);
+        botList.eraseAllBotPermissions(creditAccount);
 
-        assertEq(botList.botPermissions(bot, creditManager, creditAccount), 0, "Permissions not erased for bot 1");
-        assertEq(botList.botPermissions(otherBot, creditManager, creditAccount), 0, "Permissions not erased for bot 2");
+        assertEq(botList.botPermissions(bot, creditAccount), 0, "Permissions not erased for bot 1");
+        assertEq(botList.botPermissions(otherBot, creditAccount), 0, "Permissions not erased for bot 2");
 
-        address[] memory activeBots = botList.activeBots(creditManager, creditAccount);
+        address[] memory activeBots = botList.activeBots(creditAccount);
         assertEq(activeBots.length, 0, "Not all active bots were disabled");
     }
 
@@ -202,7 +164,7 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         vm.prank(CONFIGURATOR);
         botList.setBotSpecialPermissions(bot, creditManager, 2);
 
-        (uint192 permissions,, bool hasSpecialPermissions) = botList.getBotStatus(bot, creditManager, creditAccount);
+        (uint192 permissions,, bool hasSpecialPermissions) = botList.getBotStatus(bot, creditAccount);
 
         assertEq(permissions, 2, "Special permissions are incorrect");
         assertTrue(hasSpecialPermissions, "Special permissions status returned incorrectly");

--- a/contracts/test/unit/core/BotListV3.unit.t.sol
+++ b/contracts/test/unit/core/BotListV3.unit.t.sol
@@ -174,8 +174,11 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         botList.setBotSpecialPermissions(bot, creditManager, 2);
 
         (uint192 permissions,, bool hasSpecialPermissions) = botList.getBotStatus(bot, creditAccount);
+        address[] memory specialBots = botList.specialBots(creditManager);
 
         assertEq(permissions, 2, "Special permissions are incorrect");
         assertTrue(hasSpecialPermissions, "Special permissions status returned incorrectly");
+        assertEq(specialBots.length, 1, "Incorrect list of special bots");
+        assertEq(specialBots[0], bot, "Incorrect list of special bots");
     }
 }

--- a/contracts/test/unit/core/BotListV3.unit.t.sol
+++ b/contracts/test/unit/core/BotListV3.unit.t.sol
@@ -112,8 +112,8 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         vm.prank(CONFIGURATOR);
         botList.setBotForbiddenStatus(bot, true);
 
-        vm.expectEmit(true, true, true, false);
-        emit EraseBot(bot, creditManager, creditAccount);
+        vm.expectEmit(true, true, true, true);
+        emit SetBotPermissions(bot, creditManager, creditAccount, 0);
 
         vm.prank(creditFacade);
         activeBotsRemaining = botList.setBotPermissions({bot: bot, creditAccount: creditAccount, permissions: 0});
@@ -140,11 +140,11 @@ contract BotListV3UnitTest is Test, IBotListV3Events {
         vm.prank(invalidFacade);
         botList.eraseAllBotPermissions(creditAccount);
 
-        vm.expectEmit(true, true, true, false);
-        emit EraseBot(otherBot, creditManager, creditAccount);
+        vm.expectEmit(true, true, true, true);
+        emit SetBotPermissions(otherBot, creditManager, creditAccount, 0);
 
-        vm.expectEmit(true, true, true, false);
-        emit EraseBot(bot, creditManager, creditAccount);
+        vm.expectEmit(true, true, true, true);
+        emit SetBotPermissions(bot, creditManager, creditAccount, 0);
 
         vm.prank(creditFacade);
         botList.eraseAllBotPermissions(creditAccount);

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -710,7 +710,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
 
         uint256 enabledTokensMaskBefore = 123123123;
 
-        botListMock.setBotStatusReturns(ALL_PERMISSIONS, false, false);
+        botListMock.setBotStatusReturns(ALL_PERMISSIONS, false);
 
         creditManagerMock.setEnabledTokensMask(enabledTokensMaskBefore);
         creditManagerMock.setBorrower(USER);
@@ -752,25 +752,21 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
 
         creditManagerMock.setFlagFor(creditAccount, BOT_PERMISSIONS_SET_FLAG, true);
 
-        botListMock.setBotStatusReturns(ALL_PERMISSIONS, true, false);
+        botListMock.setBotStatusReturns(ALL_PERMISSIONS, true);
 
         vm.expectRevert(NotApprovedBotException.selector);
         creditFacade.botMulticall(creditAccount, calls);
 
-        botListMock.setBotStatusReturns(0, false, false);
+        botListMock.setBotStatusReturns(0, false);
 
         vm.expectRevert(NotApprovedBotException.selector);
         creditFacade.botMulticall(creditAccount, calls);
 
         creditManagerMock.setFlagFor(creditAccount, BOT_PERMISSIONS_SET_FLAG, false);
 
-        botListMock.setBotStatusReturns(ALL_PERMISSIONS, false, false);
+        botListMock.setBotStatusReturns(ALL_PERMISSIONS, false);
 
         vm.expectRevert(NotApprovedBotException.selector);
-        creditFacade.botMulticall(creditAccount, calls);
-
-        botListMock.setBotStatusReturns(ALL_PERMISSIONS, false, true);
-
         creditFacade.botMulticall(creditAccount, calls);
     }
 

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -129,7 +129,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
 
         addressProvider.setAddress(AP_WETH_TOKEN, tokenTestSuite.addressOf(Tokens.WETH), false);
 
-        botListMock = BotListMock(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_00));
+        botListMock = BotListMock(addressProvider.getAddressOrRevert(AP_BOT_LIST, 3_10));
 
         priceOracleMock = PriceOracleMock(addressProvider.getAddressOrRevert(AP_PRICE_ORACLE, 3_00));
 
@@ -438,10 +438,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         }
 
         if (hasBotPermissions) {
-            vm.expectCall(
-                address(botListMock),
-                abi.encodeCall(IBotListV3.eraseAllBotPermissions, (address(creditManagerMock), creditAccount))
-            );
+            vm.expectCall(address(botListMock), abi.encodeCall(IBotListV3.eraseAllBotPermissions, (creditAccount)));
         }
 
         vm.expectEmit(true, true, true, true);
@@ -1769,20 +1766,14 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
             address(creditManagerMock),
             abi.encodeCall(ICreditManagerV3.setFlagFor, (creditAccount, BOT_PERMISSIONS_SET_FLAG, true))
         );
-        vm.expectCall(
-            address(botListMock),
-            abi.encodeCall(IBotListV3.setBotPermissions, (bot, address(creditManagerMock), creditAccount, 1))
-        );
+        vm.expectCall(address(botListMock), abi.encodeCall(IBotListV3.setBotPermissions, (bot, creditAccount, 1)));
 
         vm.prank(USER);
         creditFacade.setBotPermissions({creditAccount: creditAccount, bot: bot, permissions: 1});
 
         /// It removes flag if no bots left
         botListMock.setBotPermissionsReturn(0);
-        vm.expectCall(
-            address(botListMock),
-            abi.encodeCall(IBotListV3.setBotPermissions, (bot, address(creditManagerMock), creditAccount, 1))
-        );
+        vm.expectCall(address(botListMock), abi.encodeCall(IBotListV3.setBotPermissions, (bot, creditAccount, 1)));
 
         vm.expectCall(
             address(creditManagerMock),


### PR DESCRIPTION
In this PR:
* new `IBotV3` interface that defines bot's required permissions which are checked in the bot list
* special permission bots are deprecated
* `BotListV3` interface changes:
  * redundant `creditManager` parameter removed from most functions that operate on `creditAccount`
  * `EraseBot` event removed in favor of `SetBotPermissions(..., 0)`
* minor implementation improvements that make code more consistent
* increase `BotListV3` version to `3_10`