### PR TITLE
fix: simplify forbidden tokens logic

### DIFF
--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -547,11 +547,10 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @param creditAccount Credit account to check
     /// @param enabledTokensMask Bitmask of account's enabled collateral tokens
     /// @param collateralHints Optional array of token masks to check first to reduce the amount of computation
-    ///        when known subset of account's collateral tokens covers all the debt
+    ///        when known subset of account's collateral tokens covers all the debt (underlying is always checked last)
     /// @param minHealthFactor Health factor threshold in bps, the check fails if `twvUSD < minHealthFactor * totalDebtUSD`
     /// @param useSafePrices Whether to use safe prices when evaluating collateral
-    /// @return enabledTokensMaskAfter Bitmask of account's enabled collateral tokens after potential cleanup
-    /// @dev Even when `collateralHints` are specified, quoted tokens are evaluated before non-quoted ones
+    /// @return enabledTokensMaskAfter Always 0, exists for backward compatibility
     /// @custom:expects Credit facade ensures that `creditAccount` is opened in this credit manager
     function fullCollateralCheck(
         address creditAccount,
@@ -564,7 +563,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         override
         nonReentrant // U:[CM-5]
         creditFacadeOnly // U:[CM-2]
-        returns (uint256 enabledTokensMaskAfter)
+        returns (uint256)
     {
         CollateralDebtData memory cdd = _calcDebtAndCollateral({
             creditAccount: creditAccount,
@@ -579,8 +578,8 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
             revert NotEnoughCollateralException(); // U:[CM-18B]
         }
 
-        enabledTokensMaskAfter = cdd.enabledTokensMask;
-        _saveEnabledTokensMask(creditAccount, enabledTokensMaskAfter); // U:[CM-18]
+        _saveEnabledTokensMask(creditAccount, cdd.enabledTokensMask); // U:[CM-18]
+        return 0;
     }
 
     /// @notice Whether `creditAccount`'s health factor is below `minHealthFactor`

--- a/contracts/interfaces/ICreditFacadeV3.sol
+++ b/contracts/interfaces/ICreditFacadeV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2023.
+// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
 import {MultiCall} from "@gearbox-protocol/core-v2/contracts/libraries/MultiCall.sol";
@@ -29,13 +29,13 @@ struct CumulativeLossParams {
 /// @param collateralHints Optional array of token masks to check first to reduce the amount of computation
 ///        when known subset of account's collateral tokens covers all the debt
 /// @param minHealthFactor Min account's health factor in bps in order not to revert
-/// @param enabledTokensMaskAfter Bitmask of account's enabled collateral tokens after the multicall
+/// @param enabledTokensMask Bitmask of account's enabled collateral tokens after the multicall
 /// @param revertOnForbiddenTokens Whether to revert on enabled forbidden tokens after the multicall
 /// @param useSafePrices Whether to use safe pricing (min of main and reserve feeds) when evaluating collateral
 struct FullCheckParams {
     uint256[] collateralHints;
     uint16 minHealthFactor;
-    uint256 enabledTokensMaskAfter;
+    uint256 enabledTokensMask;
     bool revertOnForbiddenTokens;
     bool useSafePrices;
 }

--- a/contracts/interfaces/ICreditFacadeV3Multicall.sol
+++ b/contracts/interfaces/ICreditFacadeV3Multicall.sol
@@ -24,9 +24,6 @@ uint256 constant ALL_PERMISSIONS = ADD_COLLATERAL_PERMISSION | WITHDRAW_COLLATER
 // FLAGS //
 // ----- //
 
-/// @dev Indicates that there are enabled forbidden tokens on the account before multicall
-uint256 constant FORBIDDEN_TOKENS_BEFORE_CALLS = 1 << 192;
-
 /// @dev Indicates that external calls from credit account to adapters were made during multicall,
 ///      set to true on the first call to the adapter
 uint256 constant EXTERNAL_CONTRACT_WAS_CALLED = 1 << 193;
@@ -95,7 +92,7 @@ interface ICreditFacadeV3Multicall {
     /// @param quotaChange Desired quota change in underlying token units (`type(int96).min` to disable quota)
     /// @param minQuota Minimum resulting account's quota for token required not to revert
     /// @dev Enables token as collateral if quota is increased from zero, disables if decreased to zero
-    /// @dev Quota increase is prohibited if there are forbidden tokens enabled as collateral on the account
+    /// @dev Quota increase is prohibited for forbidden tokens
     /// @dev Quota update is prohibited if account has zero debt
     /// @dev Resulting account's quota for token must not exceed the limit defined in the facade
     function updateQuota(address token, int96 quotaChange, uint96 minQuota) external;

--- a/contracts/interfaces/ICreditManagerV3.sol
+++ b/contracts/interfaces/ICreditManagerV3.sol
@@ -156,7 +156,7 @@ interface ICreditManagerV3 is IVersion, ICreditManagerV3Events {
         uint256[] calldata collateralHints,
         uint16 minHealthFactor,
         bool useSafePrices
-    ) external returns (uint256 enabledTokensMaskAfter);
+    ) external returns (uint256);
 
     function isLiquidatable(address creditAccount, uint16 minHealthFactor) external view returns (bool);
 

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -187,8 +187,8 @@ error BalanceLessThanExpectedException();
 /// @notice Thrown when trying to perform an action that is forbidden when credit account has enabled forbidden tokens
 error ForbiddenTokensException();
 
-/// @notice Thrown when new forbidden tokens are enabled during the multicall
-error ForbiddenTokenEnabledException();
+/// @notice Thrown when forbidden token quota is increased during the multicall
+error ForbiddenTokenQuotaIncreasedException();
 
 /// @notice Thrown when enabled forbidden token balance is increased during the multicall
 error ForbiddenTokenBalanceIncreasedException();

--- a/contracts/test/integration/credit/ManageDebt.int.t.sol
+++ b/contracts/test/integration/credit/ManageDebt.int.t.sol
@@ -135,7 +135,7 @@ contract ManegDebtIntegrationTest is IntegrationTestHelper, ICreditFacadeV3Event
         vm.prank(CONFIGURATOR);
         creditConfigurator.forbidToken(link);
 
-        vm.expectRevert(ForbiddenTokensException.selector);
+        vm.expectRevert(ForbiddenTokenQuotaIncreasedException.selector);
 
         vm.prank(USER);
         creditFacade.multicall(

--- a/contracts/test/unit/credit/CreditFacadeV3Harness.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3Harness.sol
@@ -25,7 +25,7 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
         external
         returns (FullCheckParams memory fullCheckParams)
     {
-        return _multicall(creditAccount, calls, enabledTokensMask, flags, false);
+        return _multicall(creditAccount, calls, enabledTokensMask, forbiddenTokenMask, flags, false);
     }
 
     function applyOnDemandPriceUpdatesInt(MultiCall[] calldata calls) external returns (bool) {
@@ -34,14 +34,11 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
 
     function fullCollateralCheckInt(
         address creditAccount,
-        uint256 enabledTokensMaskBefore,
         FullCheckParams memory fullCheckParams,
         BalanceWithMask[] memory forbiddenBalances,
         uint256 forbiddenTokensMask
     ) external {
-        _fullCollateralCheck(
-            creditAccount, enabledTokensMaskBefore, fullCheckParams, forbiddenBalances, forbiddenTokensMask
-        );
+        _fullCollateralCheck(creditAccount, fullCheckParams, forbiddenBalances, forbiddenTokensMask);
     }
 
     function revertIfNoPermission(uint256 flags, uint256 permission) external pure {

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -1319,7 +1319,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             cumulativeIndexLastUpdate: RAY,
             cumulativeQuotaInterest: 1,
             quotaFees: 0,
-            enabledTokensMask: enabledTokensMask,
+            enabledTokensMask: 0,
             flags: 0,
             borrower: USER
         });
@@ -1351,7 +1351,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             creditManager.isLiquidatable(creditAccount, PERCENTAGE_FACTOR),
             "isLiquidatable is true for non-liquidatable account"
         );
-        uint256 enabledTokensMaskAfter = creditManager.fullCollateralCheck({
+        creditManager.fullCollateralCheck({
             creditAccount: creditAccount,
             enabledTokensMask: enabledTokensMask,
             collateralHints: new uint256[](0),
@@ -1359,9 +1359,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             useSafePrices: false
         });
 
-        assertEq(
-            creditManager.enabledTokensMaskOf(creditAccount), enabledTokensMaskAfter, "enabledTokensMask not updated"
-        );
+        assertEq(creditManager.enabledTokensMaskOf(creditAccount), enabledTokensMask, "enabledTokensMask not updated");
     }
 
     /// @dev U:[CM-18A]: fullCollateralCheck succeeds for zero debt


### PR DESCRIPTION
Since updating quotas is now the only way to enable tokens, it's now possible to explicitly revert on trying to increase quota for a forbidden token, which slightly unclutters the code.

This commit also fixes some outdated comments.