### PR TITLE
fix: lt configuration fixes

### DIFF
--- a/contracts/libraries/CreditLogic.sol
+++ b/contracts/libraries/CreditLogic.sol
@@ -113,14 +113,12 @@ library CreditLogic {
         view
         returns (uint16)
     {
+        if (block.timestamp <= timestampRampStart) return ltInitial; // U:[CL-5]
+
         uint40 timestampRampEnd = timestampRampStart + rampDuration;
-        if (block.timestamp <= timestampRampStart) {
-            return ltInitial; // U:[CL-5]
-        } else if (block.timestamp < timestampRampEnd) {
-            return _getRampingLiquidationThreshold(ltInitial, ltFinal, timestampRampStart, timestampRampEnd); // U:[CL-5]
-        } else {
-            return ltFinal; // U:[CL-5]
-        }
+        if (block.timestamp >= timestampRampEnd) return ltFinal; // U:[CL-5]
+
+        return _getRampingLiquidationThreshold(ltInitial, ltFinal, timestampRampStart, timestampRampEnd); // U:[CL-5]
     }
 
     /// @dev Computes the LT during the ramping process

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -547,8 +547,14 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
     }
 
     function _makeAccountsLiquitable() internal {
-        vm.prank(CONFIGURATOR);
+        vm.startPrank(CONFIGURATOR);
+        uint256 idx = creditManager.collateralTokensCount() - 1;
+        while (idx != 0) {
+            address token = creditManager.getTokenByMask(1 << (idx--));
+            creditConfigurator.setLiquidationThreshold(token, 0);
+        }
         creditConfigurator.setFees(200, 9000, 100, 9500);
+        vm.stopPrank();
 
         // switch to new block to be able to close account
         vm.roll(block.number + 1);


### PR DESCRIPTION
In this PR:
* `CreditConfiguratorV3.setFees` now reverts if new underlying's LT is below any collateral token's LT (and final LT in case of ramp)
* `CreditLogic.getLiquidationThreshold` now only computes `timestampRampEnd` if `block.timestamp > timestampRampStart`, which prevents an overflow bug
* `CreditConfiguratorV3.rampLiquidationThreshold`'s NatSpec now explicitly states that if `timestampRampStart` defaults to `block.timestamp` unless it's set to the future timestamp
* Minor stylistic cleanup

Addressed findings:
* https://github.com/spearbit-audits/review-gearbox/issues/53
* https://github.com/spearbit-audits/review-gearbox/issues/54
* https://github.com/spearbit-audits/review-gearbox/issues/59
* https://github.com/spearbit-audits/review-gearbox/issues/104