### PR TITLE
feat: general credit configuration fixes

### DIFF
--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -156,7 +156,8 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     /// @param _botList Bot list address
     /// @param _weth WETH token address
     /// @param _degenNFT Degen NFT address or `address(0)`
-    /// @param _expirable Whether this facade should be expirable
+    /// @param _expirable Whether this facade should be expirable. If `true`, the expiration date remains unset,
+    ///        and facade never expires, unless the date is set via `setExpirationDate` in the configurator.
     constructor(
         address _acl,
         address _creditManager,

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -152,6 +152,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @param _feeInterest Percentage of accrued interest in bps to take by the protocol as profit
     /// @param _name Credit manager name
     /// @dev Adds pool's underlying as collateral token with LT = 0
+    /// @dev Reverts if `_priceOracle` does not have a price feed for underlying
     /// @dev Sets `msg.sender` as credit configurator
     /// @dev Reverts if `_maxEnabledTokens` is zero
     constructor(
@@ -172,6 +173,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         name = _name; // U:[CM-1]
 
         underlying = IPoolV3(_pool).underlyingToken(); // U:[CM-1]
+        if (IPriceOracleV3(_priceOracle).priceFeeds(underlying) == address(0)) revert PriceFeedDoesNotExistException(); // U:[CM-1]
         _addToken(underlying); // U:[CM-1]
 
         creditConfigurator = msg.sender; // U:[CM-1]

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -153,7 +153,9 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @param _name Credit manager name
     /// @dev Adds pool's underlying as collateral token with LT = 0
     /// @dev Reverts if `_priceOracle` does not have a price feed for underlying
-    /// @dev Sets `msg.sender` as credit configurator
+    /// @dev Sets `msg.sender` as credit configurator, which MUST then pass the role to `CreditConfiguratorV3` contract
+    ///      once it's deployed via `setCreditConfigurator`. The latter performs crucial sanity checks, and configuring
+    ///      the credit manager without them might have dramatic consequences.
     /// @dev Reverts if `_maxEnabledTokens` is zero
     constructor(
         address _pool,

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -150,6 +150,9 @@ error IncompatibleContractException();
 /// @notice Thrown if attempting to forbid an adapter that is not registered in the credit manager
 error AdapterIsNotRegisteredException();
 
+/// @notice Thrown if new credit configurator's set of allowed adapters differs from the current one
+error IncorrectAdaptersSetException();
+
 // ------------- //
 // CREDIT FACADE //
 // ------------- //

--- a/contracts/interfaces/base/IAdapter.sol
+++ b/contracts/interfaces/base/IAdapter.sol
@@ -16,8 +16,10 @@ interface IAdapter {
     function _gearboxAdapterVersion() external view returns (uint16);
 
     /// @notice Credit manager this adapter is connected to
+    /// @dev Assumed to be an immutable state variable
     function creditManager() external view returns (address);
 
     /// @notice Target contract adapter helps to interact with
+    /// @dev Assumed to be an immutable state variable
     function targetContract() external view returns (address);
 }

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -862,6 +862,30 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
         }
     }
 
+    /// @dev I:[CC-22B]: setCreditFacade reverts if new facade is adapter or target contract
+    function test_I_CC_22B_setCreditFacade_reverts_if_new_facade_is_adapter() public creditTest {
+        vm.startPrank(CONFIGURATOR);
+
+        CreditFacadeV3 cf =
+            new CreditFacadeV3(address(acl), address(creditManager), address(0), address(0), address(0), false);
+        AdapterMock adapter = new AdapterMock(address(creditManager), address(cf));
+        TargetContractMock target = new TargetContractMock();
+
+        vm.mockCall(address(cf), abi.encodeCall(IAdapter.targetContract, ()), abi.encode(address(target)));
+        creditConfigurator.allowAdapter(address(cf));
+
+        vm.expectRevert(TargetContractNotAllowedException.selector);
+        creditConfigurator.setCreditFacade(address(cf), false);
+
+        creditConfigurator.forbidAdapter(address(cf));
+        creditConfigurator.allowAdapter(address(adapter));
+
+        vm.expectRevert(TargetContractNotAllowedException.selector);
+        creditConfigurator.setCreditFacade(address(cf), false);
+
+        vm.stopPrank();
+    }
+
     /// @dev I:[CC-22C]: setCreditFacade correctly migrates array parameters
     function test_I_CC_22C_setCreditFacade_correctly_migrates_array_parameters() public creditTest {
         for (uint256 ms = 0; ms < 2; ms++) {
@@ -919,14 +943,33 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
     }
 
     /// @dev I:[CC-23]: uupgradeCreditConfigurator upgrades creditConfigurator
-    function test_I_CC_23_upgradeCreditConfigurator_upgrades_creditConfigurator() public withAdapterMock creditTest {
-        vm.expectEmit(true, false, false, false);
-        emit CreditConfiguratorUpgraded(address(adapterMock));
+    function test_I_CC_23_upgradeCreditConfigurator_upgrades_creditConfigurator() public creditTest {
+        TargetContractMock target1 = new TargetContractMock();
+        TargetContractMock target2 = new TargetContractMock();
+        AdapterMock adapter1 = new AdapterMock(address(creditManager), address(target1));
+        AdapterMock adapter2 = new AdapterMock(address(creditManager), address(target2));
 
         vm.prank(CONFIGURATOR);
-        creditConfigurator.upgradeCreditConfigurator(address(adapterMock));
+        creditConfigurator.allowAdapter(address(adapter1));
 
-        assertEq(address(creditManager.creditConfigurator()), address(adapterMock));
+        CreditConfiguratorV3 cc1 = new CreditConfiguratorV3(address(acl), address(creditManager));
+
+        vm.prank(CONFIGURATOR);
+        creditConfigurator.allowAdapter(address(adapter2));
+
+        CreditConfiguratorV3 cc2 = new CreditConfiguratorV3(address(acl), address(creditManager));
+
+        vm.expectRevert(IncorrectAdaptersSetException.selector);
+        vm.prank(CONFIGURATOR);
+        creditConfigurator.upgradeCreditConfigurator(address(cc1));
+
+        vm.expectEmit(true, true, true, true);
+        emit CreditConfiguratorUpgraded(address(cc2));
+
+        vm.prank(CONFIGURATOR);
+        creditConfigurator.upgradeCreditConfigurator(address(cc2));
+
+        assertEq(address(creditManager.creditConfigurator()), address(cc2));
     }
 
     /// @dev I:[CC-24]: setMaxDebtPerBlockMultiplier and forbidBorrowing work correctly

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -312,11 +312,12 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             isFeeToken
         );
 
+        PriceOracleMock priceOracleMock2 = new PriceOracleMock();
         vm.expectRevert(PriceFeedDoesNotExistException.selector);
         new CreditManagerV3Harness(
             address(poolMock),
             address(accountFactory),
-            address(new PriceOracleMock()),
+            address(priceOracleMock2),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
             name,

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -132,6 +132,8 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         poolQuotaKeeperMock = new PoolQuotaKeeperMock(address(poolMock), underlying);
         poolMock.setPoolQuotaKeeper(address(poolQuotaKeeperMock));
 
+        priceOracleMock.addPriceFeed(underlying, makeAddr("UNDERLYING_PRICE_FEED"));
+
         creditManager = new CreditManagerV3Harness(
             address(poolMock),
             address(accountFactory),
@@ -305,6 +307,17 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             address(accountFactory),
             address(priceOracleMock),
             0,
+            DEFAULT_FEE_INTEREST,
+            name,
+            isFeeToken
+        );
+
+        vm.expectRevert(PriceFeedDoesNotExistException.selector);
+        new CreditManagerV3Harness(
+            address(poolMock),
+            address(accountFactory),
+            address(new PriceOracleMock()),
+            DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
             name,
             isFeeToken


### PR DESCRIPTION
In this PR:
* `CreditConfiguratorV3.setPriceOracle` now ensures that new price oracle has all required price feeds
* `CreditManagerV3`'s constructor now ensures that price oracle has a price feed for the underlying token
* `CreditConfiguratorV3.upgradeCreditConfigurator` now ensures that set of allowed adapters of the new configurator coincides with the one of the current
* `CreditConfiguratorV3.setCreditFacade` now ensures that new credit facade is not an adapter or some adapter's target contract
* More comments on system behaviour 