### PR TITLE
feat: quota-related fixes

### DIFF
--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -702,6 +702,8 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLNonReentrantTrait {
     ) internal returns (uint256, uint256) {
         (address token, int96 quotaChange, uint96 minQuota) = abi.decode(callData, (address, int96, uint96)); // U:[FA-34]
 
+        if (token == underlying) revert TokenIsNotQuotedException(); // U:[FA-34]
+
         if (quotaChange > 0) {
             forbiddenTokensMask = _forbiddenTokensMaskRoE(forbiddenTokensMask);
             if (forbiddenTokensMask != 0 && _getTokenMaskOrRevert(token) & forbiddenTokensMask != 0) {

--- a/contracts/interfaces/ICreditFacadeV3Multicall.sol
+++ b/contracts/interfaces/ICreditFacadeV3Multicall.sol
@@ -119,7 +119,7 @@ interface ICreditFacadeV3Multicall {
     function decreaseDebt(uint256 amount) external;
 
     /// @notice Updates account's quota for a token
-    /// @param token Token to update the quota for
+    /// @param token Collateral token to update the quota for (can't be underlying)
     /// @param quotaChange Desired quota change in underlying token units (`type(int96).min` to disable quota)
     /// @param minQuota Minimum resulting account's quota for token required not to revert
     /// @dev Enables token as collateral if quota is increased from zero, disables if decreased to zero

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -85,8 +85,8 @@ error CreditManagerCantBorrowException();
 /// @notice Thrown when attempting to set an incompatible quota keeper contract
 error IncompatibleQuotaKeeperException();
 
-/// @notice Thrown when attempting to set an incompatible rate keeper contract
-error IncompatibleRateKeeperException();
+/// @notice Thrown when attempting to set an incompatible gauge contract
+error IncompatibleGaugeException();
 
 /// @notice Thrown when the quota is outside of min/max bounds
 error QuotaIsOutOfBoundsException();

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -82,11 +82,20 @@ error BorrowingMoreThanU2ForbiddenException();
 /// @notice Thrown when a credit manager attempts to borrow more than its limit in the current block, or in general
 error CreditManagerCantBorrowException();
 
-/// @notice Thrown when attempting to connect a quota keeper to an incompatible pool
-error IncompatiblePoolQuotaKeeperException();
+/// @notice Thrown when attempting to set an incompatible quota keeper contract
+error IncompatibleQuotaKeeperException();
+
+/// @notice Thrown when attempting to set an incompatible rate keeper contract
+error IncompatibleRateKeeperException();
 
 /// @notice Thrown when the quota is outside of min/max bounds
 error QuotaIsOutOfBoundsException();
+
+/// @notice Thrown when attempting to use an uninitialized quota keeper
+error QuotaKeeperNotInitializedException();
+
+/// @notice Thrown when attempting to initialize an already initialized quota keeper
+error QuotaKeeperAlreadyInitializedException();
 
 // -------------- //
 // CREDIT MANAGER //

--- a/contracts/interfaces/IGaugeV3.sol
+++ b/contracts/interfaces/IGaugeV3.sol
@@ -70,8 +70,6 @@ interface IGaugeV3 is IVotingContract, IRateKeeper, IGaugeV3Events {
 
     function setFrozenEpoch(bool status) external;
 
-    function isTokenAdded(address token) external view returns (bool);
-
     function addQuotaToken(address token, uint16 minRate, uint16 maxRate) external;
 
     function changeQuotaMinRate(address token, uint16 minRate) external;

--- a/contracts/interfaces/IGaugeV3.sol
+++ b/contracts/interfaces/IGaugeV3.sol
@@ -40,8 +40,6 @@ interface IGaugeV3Events {
 
 /// @title Gauge V3 interface
 interface IGaugeV3 is IVotingContract, IRateKeeper, IGaugeV3Events {
-    function pool() external view returns (address);
-
     function voter() external view returns (address);
 
     function updateEpoch() external;

--- a/contracts/interfaces/IPoolQuotaKeeperV3.sol
+++ b/contracts/interfaces/IPoolQuotaKeeperV3.sol
@@ -87,8 +87,6 @@ interface IPoolQuotaKeeperV3 is IPoolQuotaKeeperV3Events, IVersion {
         view
         returns (uint96 quoted, uint128 outstandingInterest);
 
-    function poolQuotaRevenue() external view returns (uint256);
-
     function lastQuotaRateUpdate() external view returns (uint40);
 
     // ------------- //

--- a/contracts/interfaces/IPoolQuotaKeeperV3.sol
+++ b/contracts/interfaces/IPoolQuotaKeeperV3.sol
@@ -95,11 +95,11 @@ interface IPoolQuotaKeeperV3 is IPoolQuotaKeeperV3Events, IVersion {
 
     function gauge() external view returns (address);
 
-    function setGauge(address _gauge) external;
+    function setGauge(address newGauge) external;
 
     function creditManagers() external view returns (address[] memory);
 
-    function addCreditManager(address _creditManager) external;
+    function addCreditManager(address creditManager) external;
 
     function quotedTokens() external view returns (address[] memory);
 

--- a/contracts/interfaces/IPoolQuotaKeeperV3.sol
+++ b/contracts/interfaces/IPoolQuotaKeeperV3.sol
@@ -44,64 +44,43 @@ interface IPoolQuotaKeeperV3Events {
 /// @title Pool quota keeper V3 interface
 interface IPoolQuotaKeeperV3 is IPoolQuotaKeeperV3Events, IVersion {
     function pool() external view returns (address);
-
     function underlying() external view returns (address);
+    function gauge() external view returns (address);
+
+    function isCreditManagerAdded(address creditManager) external view returns (bool);
+    function creditManagers() external view returns (address[] memory);
+
+    function isQuotedToken(address token) external view returns (bool);
+    function quotedTokens() external view returns (address[] memory);
+
+    function tokenQuotaParams(address token) external view returns (TokenQuotaParams memory);
+    function accountQuotas(address creditAccount, address token) external view returns (AccountQuota memory);
+    function lastQuotaRateUpdate() external view returns (uint40);
 
     // ----------------- //
     // QUOTAS MANAGEMENT //
     // ----------------- //
 
-    function updateQuota(address creditAccount, address token, int96 requestedChange, uint96 minQuota, uint96 maxQuota)
+    function updateQuota(address creditAccount, address token, int96 quotaChange, uint96 minQuota, uint96 maxQuota)
         external
-        returns (uint128 caQuotaInterestChange, uint128 fees, bool enableToken, bool disableToken);
+        returns (uint128 outstandingInterest, uint128 fees, bool enableToken, bool disableToken);
 
     function removeQuotas(address creditAccount, address[] calldata tokens, bool setLimitsToZero) external;
 
     function accrueQuotaInterest(address creditAccount, address[] calldata tokens) external;
-
-    function getQuotaRate(address) external view returns (uint16);
-
-    function cumulativeIndex(address token) external view returns (uint192);
-
-    function isQuotedToken(address token) external view returns (bool);
-
-    function getQuota(address creditAccount, address token)
-        external
-        view
-        returns (uint96 quota, uint192 cumulativeIndexLU);
-
-    function getTokenQuotaParams(address token)
-        external
-        view
-        returns (
-            uint16 rate,
-            uint192 cumulativeIndexLU,
-            uint16 quotaIncreaseFee,
-            uint96 totalQuoted,
-            uint96 limit,
-            bool isActive
-        );
 
     function getQuotaAndOutstandingInterest(address creditAccount, address token)
         external
         view
         returns (uint96 quoted, uint128 outstandingInterest);
 
-    function lastQuotaRateUpdate() external view returns (uint40);
-
     // ------------- //
     // CONFIGURATION //
     // ------------- //
 
-    function gauge() external view returns (address);
-
     function setGauge(address newGauge) external;
 
-    function creditManagers() external view returns (address[] memory);
-
     function addCreditManager(address creditManager) external;
-
-    function quotedTokens() external view returns (address[] memory);
 
     function addQuotaToken(address token) external;
 

--- a/contracts/interfaces/IPoolV3.sol
+++ b/contracts/interfaces/IPoolV3.sol
@@ -23,8 +23,8 @@ interface IPoolV3Events {
     /// @notice Emitted when new interest rate model contract is set
     event SetInterestRateModel(address indexed newInterestRateModel);
 
-    /// @notice Emitted when new pool quota keeper contract is set
-    event SetPoolQuotaKeeper(address indexed newPoolQuotaKeeper);
+    /// @notice Emitted when the quota keeper contract is initialized
+    event SetPoolQuotaKeeper(address indexed quotaKeeper);
 
     /// @notice Emitted when new total debt limit is set
     event SetTotalDebtLimit(uint256 limit);
@@ -121,7 +121,7 @@ interface IPoolV3 is IVersion, IPoolV3Events, IERC4626, IERC20Permit {
 
     function setInterestRateModel(address newInterestRateModel) external;
 
-    function setPoolQuotaKeeper(address newPoolQuotaKeeper) external;
+    function setPoolQuotaKeeper(address quotaKeeper) external;
 
     function setTotalDebtLimit(uint256 newLimit) external;
 

--- a/contracts/interfaces/ITumblerV3.sol
+++ b/contracts/interfaces/ITumblerV3.sol
@@ -15,12 +15,6 @@ interface ITumblerV3Events {
 
 /// @title Tumbler V3 interface
 interface ITumblerV3 is IRateKeeper, ITumblerV3Events {
-    function pool() external view returns (address);
-
-    function underlying() external view returns (address);
-
-    function poolQuotaKeeper() external view returns (address);
-
     function epochLength() external view returns (uint256);
 
     function getTokens() external view returns (address[] memory);

--- a/contracts/interfaces/base/IRateKeeper.sol
+++ b/contracts/interfaces/base/IRateKeeper.sol
@@ -11,6 +11,10 @@ interface IRateKeeper is IVersion {
     /// @notice Quota keeper rates are provided for
     function quotaKeeper() external view returns (address);
 
-    /// @notice Returns quota rates for a list of tokens, must revert for unrecognized tokens
+    /// @notice Whether token is added to the rate keeper
+    function isTokenAdded(address token) external view returns (bool);
+
+    /// @notice Returns quota rates for a list of tokens, must return non-zero rates for added tokens
+    ///         and revert if some tokens are not recognized
     function getRates(address[] calldata tokens) external view returns (uint16[] memory);
 }

--- a/contracts/interfaces/base/IRateKeeper.sol
+++ b/contracts/interfaces/base/IRateKeeper.sol
@@ -8,6 +8,9 @@ import {IVersion} from "./IVersion.sol";
 /// @title Rate keeper interface
 /// @notice Generic interface for a contract that can provide rates to the quota keeper
 interface IRateKeeper is IVersion {
+    /// @notice Quota keeper rates are provided for
+    function quotaKeeper() external view returns (address);
+
     /// @notice Returns quota rates for a list of tokens, must revert for unrecognized tokens
     function getRates(address[] calldata tokens) external view returns (uint16[] memory);
 }

--- a/contracts/pool/GaugeV3.sol
+++ b/contracts/pool/GaugeV3.sol
@@ -50,6 +50,12 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
     /// @notice Whether gauge is frozen and rates cannot be updated
     bool public override epochFrozen;
 
+    /// @dev Ensures that function caller is voter
+    modifier onlyVoter() {
+        _revertIfCallerNotVoter(); // U:[GA-2]
+        _;
+    }
+
     /// @notice Constructor
     /// @param _acl ACL contract address
     /// @param _quotaKeeper Address of the quota keeper to provide rates for
@@ -64,12 +70,6 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
         epochLastUpdate = IGearStakingV3(_gearStaking).getCurrentEpoch(); // U:[GA-1]
         epochFrozen = true; // U:[GA-1]
         emit SetFrozenEpoch(true); // U:[GA-1]
-    }
-
-    /// @dev Ensures that function caller is voter
-    modifier onlyVoter() {
-        _revertIfCallerNotVoter(); // U:[GA-2]
-        _;
     }
 
     /// @notice Updates the epoch and, unless frozen, rates in the quota keeper
@@ -246,7 +246,7 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
         emit AddQuotaToken({token: token, minRate: minRate, maxRate: maxRate}); // U:[GA-5]
     }
 
-    /// @dev Changes the min rate for a quoted token
+    /// @notice Changes the min rate for a quoted token
     /// @param minRate The minimal interest rate paid on token's quotas
     function changeQuotaMinRate(address token, uint16 minRate)
         external
@@ -257,7 +257,7 @@ contract GaugeV3 is IGaugeV3, ACLNonReentrantTrait {
         _changeQuotaTokenRateParams(token, minRate, quotaRateParams[token].maxRate);
     }
 
-    /// @dev Changes the max rate for a quoted token
+    /// @notice Changes the max rate for a quoted token
     /// @param maxRate The maximal interest rate paid on token's quotas
     function changeQuotaMaxRate(address token, uint16 maxRate)
         external

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -325,27 +325,6 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ACLNonReentrantTrait, Contract
         isActive = rate != 0;
     }
 
-    /// @notice Returns the pool's quota revenue (in units of underlying per year)
-    function poolQuotaRevenue() external view virtual override returns (uint256 quotaRevenue) {
-        address[] memory tokens = quotaTokensSet.values();
-
-        uint256 len = tokens.length;
-
-        for (uint256 i; i < len;) {
-            address token = tokens[i];
-
-            TokenQuotaParams storage tokenQuotaParams = totalQuotaParams[token];
-            (uint16 rate,,) = _getTokenQuotaParamsOrRevert(tokenQuotaParams);
-            (uint256 totalQuoted,) = _getTokenQuotaTotalAndLimit(tokenQuotaParams);
-
-            quotaRevenue += totalQuoted * rate / PERCENTAGE_FACTOR;
-
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
     /// @notice Returns the list of allowed credit managers
     function creditManagers() external view override returns (address[] memory) {
         return creditManagerSet.values(); // U:[PQK-10]

--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -38,9 +38,9 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
     mapping(address => uint16) internal _rates;
 
     /// @notice Constructor
-    /// @param acl_ ACL contract address
-    /// @param quotaKeeper_ Address of the quota keeper to provide rates for
-    /// @param epochLength_ Epoch length in seconds
+    /// @param  acl_ ACL contract address
+    /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
+    /// @param  epochLength_ Epoch length in seconds
     /// @custom:tests U:[TU-1]
     constructor(address acl_, address quotaKeeper_, uint256 epochLength_)
         ACLNonReentrantTrait(acl_)
@@ -48,6 +48,12 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
     {
         quotaKeeper = quotaKeeper_;
         epochLength = epochLength_;
+    }
+
+    /// @notice Whether `token` is added to the tumbler
+    /// @custom:tests U:[TU-2]
+    function isTokenAdded(address token) public view override returns (bool) {
+        return _tokensSet.contains(token);
     }
 
     /// @notice Returns all supported tokens
@@ -63,7 +69,7 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
         rates = new uint16[](len);
         unchecked {
             for (uint256 i; i < len; ++i) {
-                if (!_tokensSet.contains(tokens[i])) revert TokenIsNotQuotedException();
+                if (!isTokenAdded(tokens[i])) revert TokenIsNotQuotedException();
                 rates[i] = _rates[tokens[i]];
             }
         }
@@ -71,7 +77,7 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
 
     /// @notice Adds `token` to the set of supported tokens and to the quota keeper unless it's already there,
     ///         sets its rate to `rate`
-    /// @dev Reverts if `token` is zero address, is already added, or `rate` is zero
+    /// @dev    Reverts if `token` is zero address, is already added, or `rate` is zero
     /// @custom:tests U:[TU-2]
     function addToken(address token, uint16 rate) external override configuratorOnly nonZeroAddress(token) {
         if (!_tokensSet.add(token)) revert TokenNotAllowedException();
@@ -83,11 +89,11 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
         _setRate(token, rate);
     }
 
-    /// @dev Sets `token`'s rate to `rate`
-    /// @dev Reverts if `token` is not added or `rate` is zero
+    /// @notice Sets `token`'s rate to `rate`
+    /// @dev    Reverts if `token` is not added or `rate` is zero
     /// @custom:tests U:[TU-3]
     function setRate(address token, uint16 rate) external override controllerOnly {
-        if (!_tokensSet.contains(token)) revert TokenIsNotQuotedException();
+        if (!isTokenAdded(token)) revert TokenIsNotQuotedException();
         _setRate(token, rate);
     }
 

--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -25,14 +25,8 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
     /// @notice Contract version
     uint256 public constant override version = 3_10;
 
-    /// @notice Pool whose quota rates are set by this contract
-    address public immutable override pool;
-
-    /// @notice Pool's underlying token
-    address public immutable override underlying;
-
-    /// @notice Pool's quota keeper
-    address public immutable override poolQuotaKeeper;
+    /// @notice Quota keeper rates are provided for
+    address public immutable override quotaKeeper;
 
     /// @notice Epoch length in seconds
     uint256 public immutable override epochLength;
@@ -45,13 +39,14 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
 
     /// @notice Constructor
     /// @param acl_ ACL contract address
-    /// @param pool_ Pool whose quota rates to set by this contract
+    /// @param quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param epochLength_ Epoch length in seconds
     /// @custom:tests U:[TU-1]
-    constructor(address acl_, address pool_, uint256 epochLength_) ACLNonReentrantTrait(acl_) {
-        pool = pool_;
-        underlying = IPoolV3(pool_).underlyingToken();
-        poolQuotaKeeper = IPoolV3(pool_).poolQuotaKeeper();
+    constructor(address acl_, address quotaKeeper_, uint256 epochLength_)
+        ACLNonReentrantTrait(acl_)
+        nonZeroAddress(quotaKeeper_)
+    {
+        quotaKeeper = quotaKeeper_;
         epochLength = epochLength_;
     }
 
@@ -76,12 +71,12 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
 
     /// @notice Adds `token` to the set of supported tokens and to the quota keeper unless it's already there,
     ///         sets its rate to `rate`
-    /// @dev Reverts if `token` is zero address, pool's underlying or is already added
+    /// @dev Reverts if `token` is zero address, is already added, or `rate` is zero
     /// @custom:tests U:[TU-2]
     function addToken(address token, uint16 rate) external override configuratorOnly nonZeroAddress(token) {
-        if (token == underlying || !_tokensSet.add(token)) revert TokenNotAllowedException();
-        if (!IPoolQuotaKeeperV3(poolQuotaKeeper).isQuotedToken(token)) {
-            IPoolQuotaKeeperV3(poolQuotaKeeper).addQuotaToken(token);
+        if (!_tokensSet.add(token)) revert TokenNotAllowedException();
+        if (!IPoolQuotaKeeperV3(quotaKeeper).isQuotedToken(token)) {
+            IPoolQuotaKeeperV3(quotaKeeper).addQuotaToken(token);
         }
         emit AddToken(token);
 
@@ -93,19 +88,19 @@ contract TumblerV3 is ITumblerV3, ACLNonReentrantTrait {
     /// @custom:tests U:[TU-3]
     function setRate(address token, uint16 rate) external override controllerOnly {
         if (!_tokensSet.contains(token)) revert TokenIsNotQuotedException();
-        if (rate == 0) revert IncorrectParameterException();
         _setRate(token, rate);
     }
 
     /// @notice Updates rates in the quota keeper if time passed since the last update is greater than epoch length
     /// @custom:tests U:[TU-4], I:[QR-1]
     function updateRates() external override controllerOnly {
-        if (block.timestamp < IPoolQuotaKeeperV3(poolQuotaKeeper).lastQuotaRateUpdate() + epochLength) return;
-        IPoolQuotaKeeperV3(poolQuotaKeeper).updateRates();
+        if (block.timestamp < IPoolQuotaKeeperV3(quotaKeeper).lastQuotaRateUpdate() + epochLength) return;
+        IPoolQuotaKeeperV3(quotaKeeper).updateRates();
     }
 
     /// @dev `setRate` implementation
     function _setRate(address token, uint16 rate) internal {
+        if (rate == 0) revert IncorrectParameterException();
         if (_rates[token] == rate) return;
         _rates[token] = rate;
         emit SetRate(token, rate);

--- a/contracts/test/config/MockCreditConfig.sol
+++ b/contracts/test/config/MockCreditConfig.sol
@@ -62,13 +62,13 @@ contract MockCreditConfig is Test, IPoolV3DeployConfig {
         _gaugeRates.push(GaugeRate({token: Tokens.CVX, minRate: 1, maxRate: 10_000}));
         _gaugeRates.push(GaugeRate({token: Tokens.STETH, minRate: 1, maxRate: 10_000}));
 
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.USDC, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.USDT, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.WETH, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.LINK, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.CRV, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.CVX, quotaIncreaseFee: 0, limit: type(uint96).max}));
-        _quotaLimits.push(PoolQuotaLimit({token: Tokens.STETH, quotaIncreaseFee: 0, limit: type(uint96).max}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.USDC, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.USDT, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.WETH, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.LINK, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.CRV, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.CVX, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
+        _quotaLimits.push(PoolQuotaLimit({token: Tokens.STETH, quotaIncreaseFee: 0, limit: uint96(type(int96).max)}));
 
         CreditManagerV3DeployParams storage cp = _creditManagers.push();
 

--- a/contracts/test/gas/pool/Gauge.gas.t.sol
+++ b/contracts/test/gas/pool/Gauge.gas.t.sol
@@ -30,7 +30,7 @@ contract GaugeGasTest is IntegrationTestHelper {
 
                 vm.startPrank(CONFIGURATOR);
                 gauge.addQuotaToken(address(token), 500, 500);
-                poolQuotaKeeper.setTokenLimit(address(token), type(uint96).max);
+                poolQuotaKeeper.setTokenLimit(address(token), uint96(type(int96).max));
                 vm.stopPrank();
 
                 vm.warp(block.timestamp + 7 days);

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -303,7 +303,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
         uint256 tokensCountBefore = creditManager.collateralTokensCount();
 
         address newToken = tokenTestSuite.addressOf(Tokens.wstETH);
-        makeTokenQuoted(newToken, 1, type(uint96).max);
+        makeTokenQuoted(newToken, 1, uint96(type(int96).max));
 
         vm.expectEmit(true, false, false, false);
         emit AddCollateralToken(newToken);

--- a/contracts/test/integration/credit/Quotas.int.t.sol
+++ b/contracts/test/integration/credit/Quotas.int.t.sol
@@ -352,13 +352,17 @@ contract QuotasIntegrationTest is IntegrationTestHelper, ICreditManagerV3Events 
             "Incorrect pool balance"
         );
 
-        (uint96 quota, uint192 cumulativeIndexLU) =
-            poolQuotaKeeper.getQuota(creditAccount, tokenTestSuite.addressOf(Tokens.LINK));
+        assertEq(
+            poolQuotaKeeper.accountQuotas(creditAccount, tokenTestSuite.addressOf(Tokens.LINK)).quota,
+            0,
+            "Quota was not set to 0"
+        );
 
-        assertEq(uint256(quota), 0, "Quota was not set to 0");
-
-        (quota, cumulativeIndexLU) = poolQuotaKeeper.getQuota(creditAccount, tokenTestSuite.addressOf(Tokens.USDT));
-        assertEq(uint256(quota), 0, "Quota was not set to 0");
+        assertEq(
+            poolQuotaKeeper.accountQuotas(creditAccount, tokenTestSuite.addressOf(Tokens.USDT)).quota,
+            0,
+            "Quota was not set to 0"
+        );
     }
 
     /// @dev I:[CMQ-07]: calcDebtAndCollateral correctly counts quota interest
@@ -450,9 +454,7 @@ contract QuotasIntegrationTest is IntegrationTestHelper, ICreditManagerV3Events 
         creditFacade.liquidateCreditAccount(creditAccount, FRIEND, new MultiCall[](0));
 
         for (uint256 i = 0; i < quotedTokens.length; ++i) {
-            (,,, uint96 limit,,) = poolQuotaKeeper.getTokenQuotaParams(quotedTokens[i]);
-
-            assertEq(limit, 0, "Limit was not zeroed");
+            assertEq(poolQuotaKeeper.tokenQuotaParams(quotedTokens[i]).limit, 0, "Limit was not zeroed");
         }
     }
 

--- a/contracts/test/integration/governance/GaugeMigration.int.t.sol
+++ b/contracts/test/integration/governance/GaugeMigration.int.t.sol
@@ -56,7 +56,7 @@ contract GaugeMigrationIntegrationTest is Test {
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
         // deploy gauge and connect it to the quota keeper and staking
-        gauge = new GaugeV3(address(addressProvider), address(pool), address(staking));
+        gauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(staking));
         staking.setVotingContractStatus(address(gauge), VotingContractStatus.ALLOWED);
         quotaKeeper.setGauge(address(gauge));
 
@@ -102,7 +102,7 @@ contract GaugeMigrationIntegrationTest is Test {
     function test_I_GAM_01_gauge_migration_works_as_expected() public {
         // prepare a new gauge and disable an old one
         vm.startPrank(configurator);
-        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(pool), address(staking));
+        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(staking));
 
         staking.setVotingContractStatus(address(newGauge), VotingContractStatus.ALLOWED);
         staking.setVotingContractStatus(address(gauge), VotingContractStatus.UNVOTE_ONLY);
@@ -167,7 +167,7 @@ contract GaugeMigrationIntegrationTest is Test {
         // prepare new staking and gauge contracts
         vm.startPrank(configurator);
         GearStakingV3 newStaking = new GearStakingV3(configurator, address(gear), block.timestamp);
-        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(pool), address(newStaking));
+        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(newStaking));
 
         newStaking.setMigrator(address(staking));
         staking.setSuccessor(address(newStaking));

--- a/contracts/test/integration/governance/GaugeMigration.int.t.sol
+++ b/contracts/test/integration/governance/GaugeMigration.int.t.sol
@@ -94,8 +94,8 @@ contract GaugeMigrationIntegrationTest is Test {
         gauge.updateEpoch();
 
         // validate correctness
-        assertEq(quotaKeeper.getQuotaRate(address(token1)), 2200, "Incorrect token1 rate");
-        assertEq(quotaKeeper.getQuotaRate(address(token2)), 400, "Incorrect token2 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token1)).rate, 2200, "Incorrect token1 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token2)).rate, 400, "Incorrect token2 rate");
     }
 
     /// @notice I:[GAM-1]: Gauge migration works as expected
@@ -154,8 +154,8 @@ contract GaugeMigrationIntegrationTest is Test {
         newGauge.updateEpoch();
 
         // validate correctness
-        assertEq(quotaKeeper.getQuotaRate(address(token1)), 2200, "Incorrect token1 rate");
-        assertEq(quotaKeeper.getQuotaRate(address(token2)), 1200, "Incorrect token2 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token1)).rate, 2200, "Incorrect token1 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token2)).rate, 1200, "Incorrect token2 rate");
 
         // check that new gauge can be used to add tokens to quota keeper
         vm.prank(configurator);
@@ -226,8 +226,8 @@ contract GaugeMigrationIntegrationTest is Test {
         newGauge.updateEpoch();
 
         // validate correctness
-        assertEq(quotaKeeper.getQuotaRate(address(token1)), 2200, "Incorrect token1 rate");
-        assertEq(quotaKeeper.getQuotaRate(address(token2)), 1200, "Incorrect token2 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token1)).rate, 2200, "Incorrect token1 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token2)).rate, 1200, "Incorrect token2 rate");
 
         // check that new gauge can be used to add tokens to quota keeper
         vm.prank(configurator);

--- a/contracts/test/integration/governance/QuotaRates.int.t.sol
+++ b/contracts/test/integration/governance/QuotaRates.int.t.sol
@@ -34,7 +34,7 @@ contract QuotaRatesIntegrationTest is Test {
         quotaKeeper = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(pool));
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
-        tumbler = new TumblerV3(address(addressProvider), address(pool), 1 days);
+        tumbler = new TumblerV3(address(addressProvider), address(quotaKeeper), 1 days);
         quotaKeeper.setGauge(address(tumbler));
     }
 

--- a/contracts/test/integration/governance/QuotaRates.int.t.sol
+++ b/contracts/test/integration/governance/QuotaRates.int.t.sol
@@ -51,7 +51,7 @@ contract QuotaRatesIntegrationTest is Test {
         vm.expectCall(address(tumbler), abi.encodeCall(tumbler.getRates, (tokens)));
 
         tumbler.updateRates();
-        assertEq(quotaKeeper.getQuotaRate(address(token1)), 4200, "Incorrect token1 rate");
-        assertEq(quotaKeeper.getQuotaRate(address(token2)), 12000, "Incorrect token2 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token1)).rate, 4200, "Incorrect token1 rate");
+        assertEq(quotaKeeper.tokenQuotaParams(address(token2)).rate, 12000, "Incorrect token2 rate");
     }
 }

--- a/contracts/test/mocks/governance/GaugeMock.sol
+++ b/contracts/test/mocks/governance/GaugeMock.sol
@@ -44,6 +44,10 @@ contract GaugeMock is ACLNonReentrantTrait {
         IPoolQuotaKeeperV3(quotaKeeper).addQuotaToken(token);
     }
 
+    function isTokenAdded(address token) external view returns (bool) {
+        return rates[token] != 0;
+    }
+
     function changeQuotaTokenRateParams(address token, uint16 rate) external configuratorOnly {
         rates[token] = rate;
     }

--- a/contracts/test/mocks/governance/GaugeMock.sol
+++ b/contracts/test/mocks/governance/GaugeMock.sol
@@ -20,8 +20,7 @@ contract GaugeMock is ACLNonReentrantTrait {
     using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20 for IERC20;
 
-    /// @dev Address of the pool
-    PoolV3 public immutable pool;
+    address public quotaKeeper;
 
     /// @dev Mapping from token address to its rate parameters
     mapping(address => uint16) public rates;
@@ -31,35 +30,18 @@ contract GaugeMock is ACLNonReentrantTrait {
     //
 
     /// @dev Constructor
-
-    constructor(address acl, address _pool) ACLNonReentrantTrait(acl) nonZeroAddress(_pool) {
-        pool = PoolV3(payable(_pool)); // F:[P4-01]
+    constructor(address acl, address quotaKeeper_) ACLNonReentrantTrait(acl) nonZeroAddress(quotaKeeper_) {
+        quotaKeeper = quotaKeeper_;
     }
 
     /// @dev Rolls the new epoch and updates all quota rates
     function updateEpoch() external {
-        /// compute all compounded rates
-        IPoolQuotaKeeperV3 keeper = IPoolQuotaKeeperV3(pool.poolQuotaKeeper());
-
-        // /// update rates & cumulative indexes
-        // address[] memory tokens = keeper.quotedTokens();
-        // uint256 len = tokens.length;
-        // uint16[] memory rateUpdates = new uint16[](len);
-
-        // unchecked {
-        //     for (uint256 i; i < len; ++i) {
-        //         address token = tokens[i];
-        //         rateUpdates[i] = rates[token];
-        //     }
-        // }
-
-        keeper.updateRates();
+        IPoolQuotaKeeperV3(quotaKeeper).updateRates();
     }
 
     function addQuotaToken(address token, uint16 rate) external configuratorOnly {
         rates[token] = rate;
-        IPoolQuotaKeeperV3 keeper = IPoolQuotaKeeperV3(pool.poolQuotaKeeper());
-        keeper.addQuotaToken(token);
+        IPoolQuotaKeeperV3(quotaKeeper).addQuotaToken(token);
     }
 
     function changeQuotaTokenRateParams(address token, uint16 rate) external configuratorOnly {

--- a/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
+++ b/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
@@ -139,11 +139,6 @@ contract PoolQuotaKeeperMock is IPoolQuotaKeeperV3 {
         return (aq.quota, aq.cumulativeIndexLU);
     }
 
-    /// @notice Returns the current annual quota revenue to the pool
-    function poolQuotaRevenue() external view virtual override returns (uint256 quotaRevenue) {
-        return 0;
-    }
-
     function getTokenQuotaParams(address)
         external
         pure

--- a/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
+++ b/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
@@ -14,12 +14,6 @@ contract PoolQuotaKeeperMock is IPoolQuotaKeeperV3 {
     /// @dev Address of the protocol treasury
     address public immutable override pool;
 
-    /// @dev Mapping from token address to its respective quota parameters
-    TokenQuotaParams public totalQuotaParam;
-
-    /// @dev Mapping from creditAccount => token > quota parameters
-    AccountQuota public accountQuota;
-
     /// @dev Address of the gauge that determines quota rates
     address public gauge;
 
@@ -49,6 +43,12 @@ contract PoolQuotaKeeperMock is IPoolQuotaKeeperV3 {
         pool = _pool;
         underlying = _underlying;
     }
+
+    function tokenQuotaParams(address) external pure returns (TokenQuotaParams memory) {}
+
+    function accountQuotas(address, address) external pure returns (AccountQuota memory) {}
+
+    function isCreditManagerAdded(address) external pure returns (bool) {}
 
     function updateQuota(address, address, int96, uint96, uint96)
         external
@@ -105,16 +105,6 @@ contract PoolQuotaKeeperMock is IPoolQuotaKeeperV3 {
         interest = _outstandingInterest[token];
     }
 
-    /// @dev Returns cumulative index in RAY for a quoted token. Returns 0 for non-quoted tokens.
-    function cumulativeIndex(address token) public view override returns (uint192) {
-        //        return totalQuotaParams[token].cumulativeIndexSince(lastQuotaRateUpdate);
-    }
-
-    /// @dev Returns quota rate in PERCENTAGE FORMAT
-    function getQuotaRate(address) external view override returns (uint16) {
-        return totalQuotaParam.rate;
-    }
-
     /// @dev Returns an array of all quoted tokens
     function quotedTokens() external view override returns (address[] memory) {
         //        return quotaTokensSet.values();
@@ -131,27 +121,6 @@ contract PoolQuotaKeeperMock is IPoolQuotaKeeperV3 {
 
     function set_lastQuotaRateUpdate(uint40 value) external {
         lastQuotaRateUpdate = value;
-    }
-
-    /// @dev Returns quota parameters for a single (account, token) pair
-    function getQuota(address, address) external view returns (uint96 quota, uint192 cumulativeIndexLU) {
-        AccountQuota storage aq = accountQuota;
-        return (aq.quota, aq.cumulativeIndexLU);
-    }
-
-    function getTokenQuotaParams(address)
-        external
-        pure
-        returns (
-            uint16 rate,
-            uint192 cumulativeIndexLU,
-            uint16 quotaIncreaseFee,
-            uint96 totalQuoted,
-            uint96 limit,
-            bool isActive
-        )
-    {
-        return (0, 0, 0, 0, 0, false);
     }
 
     function addCreditManager(address _creditManager) external {}

--- a/contracts/test/suites/PoolFactory.sol
+++ b/contracts/test/suites/PoolFactory.sol
@@ -56,22 +56,22 @@ contract PoolFactory is Test {
             symbol_: config.symbol()
         });
 
-        address gearStaking = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_GEAR_STAKING, 3_10);
-        gauge = new GaugeV3(acl, address(pool), gearStaking);
-        vm.prank(CONFIGURATOR);
-        gauge.setFrozenEpoch(false);
-
-        vm.label(address(gauge), string.concat("GaugeV3-", config.symbol()));
-
         poolQuotaKeeper = new PoolQuotaKeeperV3(acl, contractsRegister, payable(address(pool)));
-
-        vm.prank(CONFIGURATOR);
-        poolQuotaKeeper.setGauge(address(gauge));
 
         vm.prank(CONFIGURATOR);
         pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
 
         vm.label(address(poolQuotaKeeper), string.concat("PoolQuotaKeeperV3-", config.symbol()));
+
+        address gearStaking = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_GEAR_STAKING, 3_10);
+        gauge = new GaugeV3(acl, address(poolQuotaKeeper), gearStaking);
+        vm.prank(CONFIGURATOR);
+        gauge.setFrozenEpoch(false);
+
+        vm.label(address(gauge), string.concat("GaugeV3-", config.symbol()));
+
+        vm.prank(CONFIGURATOR);
+        poolQuotaKeeper.setGauge(address(gauge));
 
         GaugeRate[] memory gaugeRates = config.gaugeRates();
 

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -1337,6 +1337,20 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
     function test_U_FA_34_multicall_updateQuota_works_properly() public notExpirableCase {
         address creditAccount = DUMB_ADDRESS;
 
+        address underlying = tokenTestSuite.addressOf(Tokens.DAI);
+        vm.expectRevert(TokenIsNotQuotedException.selector);
+        creditFacade.multicallInt({
+            creditAccount: creditAccount,
+            calls: MultiCallBuilder.build(
+                MultiCall({
+                    target: address(creditFacade),
+                    callData: abi.encodeCall(ICreditFacadeV3Multicall.updateQuota, (underlying, 0, 0))
+                })
+            ),
+            enabledTokensMask: 0,
+            flags: UPDATE_QUOTA_PERMISSION
+        });
+
         uint96 maxDebt = 443330;
 
         vm.prank(CONFIGURATOR);

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -325,6 +325,11 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
         );
 
         assertEq(address(creditManager.pool()), address(poolMock), _testCaseErr("Incorrect pool"));
+        assertEq(
+            address(creditManager.poolQuotaKeeper()),
+            address(poolQuotaKeeperMock),
+            _testCaseErr("Incorrect poolQuotaKeeper")
+        );
 
         assertEq(creditManager.underlying(), tokenTestSuite.addressOf(Tokens.DAI), _testCaseErr("Incorrect underlying"));
 
@@ -1829,8 +1834,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
             (address[] memory quotaTokens, uint256 outstandingQuotaInterest,) = creditManager.getQuotedTokensData({
                 creditAccount: DUMB_ADDRESS,
                 enabledTokensMask: _case.enabledTokensMask,
-                collateralHints: new uint256[](0),
-                _poolQuotaKeeper: address(poolQuotaKeeperMock)
+                collateralHints: new uint256[](0)
             });
 
             assertEq(quotaTokens, _case.expectedQuotaTokens, _testCaseErr("Incorrect quotedTokens"));
@@ -2293,12 +2297,5 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
 
         assertEq(creditManager.creditConfigurator(), DUMB_ADDRESS, "creditConfigurator is not set correctly");
         vm.stopPrank();
-    }
-
-    /// @dev U:[CM-47]: poolQuotaKeeper works correctly
-    function test_U_CM_47_poolQuotaKeeper_works_correctly() public creditManagerTest {
-        poolMock.setPoolQuotaKeeper(DUMB_ADDRESS);
-
-        assertEq(creditManager.poolQuotaKeeper(), DUMB_ADDRESS, "Incorrect poolQuotaKeeper");
     }
 }

--- a/contracts/test/unit/credit/CreditManagerV3Harness.sol
+++ b/contracts/test/unit/credit/CreditManagerV3Harness.sol
@@ -112,13 +112,12 @@ contract CreditManagerV3Harness is CreditManagerV3, USDT_Transfer {
         _saveEnabledTokensMask(creditAccount, enabledTokensMask);
     }
 
-    function getQuotedTokensData(
-        address creditAccount,
-        uint256 enabledTokensMask,
-        uint256[] memory collateralHints,
-        address _poolQuotaKeeper
-    ) external view returns (address[] memory quotaTokens, uint256 outstandingQuotaInterest, uint256[] memory quotas) {
-        return _getQuotedTokensData(creditAccount, enabledTokensMask, collateralHints, _poolQuotaKeeper);
+    function getQuotedTokensData(address creditAccount, uint256 enabledTokensMask, uint256[] memory collateralHints)
+        external
+        view
+        returns (address[] memory quotaTokens, uint256 outstandingQuotaInterest, uint256[] memory quotas)
+    {
+        return _getQuotedTokensData(creditAccount, enabledTokensMask, collateralHints);
     }
 
     function getCollateralTokensData(uint256 tokenMask) external view returns (CollateralTokenData memory) {

--- a/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
@@ -90,14 +90,14 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
     // TESTS
     //
 
-    /// @notice U:[PQK-1]: constructor sets parameters correctly
-    function test_U_PQK_01_constructor_sets_parameters_correctly() public {
+    /// @notice U:[QK-1]: constructor sets parameters correctly
+    function test_U_QK_01_constructor_sets_parameters_correctly() public {
         assertEq(address(poolMock), pqk.pool(), "Incorrect poolMock address");
         assertEq(underlying, pqk.underlying(), "Incorrect poolMock address");
     }
 
-    /// @notice U:[PQK-2]: configuration functions revert if called nonConfigurator(nonController)
-    function test_U_PQK_02_configuration_functions_reverts_if_call_nonConfigurator() public {
+    /// @notice U:[QK-2]: configuration functions revert if called nonConfigurator(nonController)
+    function test_U_QK_02_configuration_functions_reverts_if_call_nonConfigurator() public {
         vm.startPrank(USER);
 
         vm.expectRevert(CallerNotConfiguratorException.selector);
@@ -115,8 +115,8 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         vm.stopPrank();
     }
 
-    /// @notice U:[PQK-3]: gaugeOnly funcitons revert if called by non-gauge contract
-    function test_U_PQK_03_gaugeOnly_funcitons_reverts_if_called_by_non_gauge() public {
+    /// @notice U:[QK-3]: gaugeOnly funcitons revert if called by non-gauge contract
+    function test_U_QK_03_gaugeOnly_funcitons_reverts_if_called_by_non_gauge() public {
         vm.startPrank(USER);
 
         vm.expectRevert(CallerNotGaugeException.selector);
@@ -128,8 +128,8 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         vm.stopPrank();
     }
 
-    /// @notice U:[PQK-4]: creditManagerOnly funcitons revert if called by non registered creditManager
-    function test_U_PQK_04_creditManagerOnly_funcitons_reverts_if_called_by_non_gauge() public {
+    /// @notice U:[QK-4]: creditManagerOnly funcitons revert if called by non registered creditManager
+    function test_U_QK_04_creditManagerOnly_funcitons_reverts_if_called_by_non_creditManager() public {
         vm.startPrank(USER);
 
         vm.expectRevert(CallerNotCreditManagerException.selector);
@@ -144,8 +144,14 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         vm.stopPrank();
     }
 
-    /// @notice U:[PQK-5]: addQuotaToken adds token and set parameters correctly
-    function test_U_PQK_05_addQuotaToken_adds_token_and_set_parameters_correctly() public {
+    /// @notice U:[QK-5]: addQuotaToken adds token and set parameters correctly
+    function test_U_QK_05_addQuotaToken_adds_token_and_set_parameters_correctly() public {
+        address gauge = pqk.gauge();
+
+        vm.prank(gauge);
+        vm.expectRevert(TokenNotAllowedException.selector);
+        pqk.addQuotaToken(underlying);
+
         address[] memory tokens = pqk.quotedTokens();
 
         assertEq(tokens.length, 0, "SETUP: tokens set unexpectedly has tokens");
@@ -153,7 +159,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         vm.expectEmit(true, true, false, false);
         emit AddQuotaToken(DUMB_ADDRESS);
 
-        vm.prank(pqk.gauge());
+        vm.prank(gauge);
         pqk.addQuotaToken(DUMB_ADDRESS);
 
         tokens = pqk.quotedTokens();
@@ -162,32 +168,20 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         assertEq(tokens[0], DUMB_ADDRESS, "Incorrect address was added to quotaTokenSet");
         assertEq(tokens.length, 1, "token wasn't added to quotaTokenSet");
 
-        (uint16 rate, uint192 cumulativeIndexLU_RAY,, uint96 totalQuoted, uint96 limit,) =
-            pqk.getTokenQuotaParams(DUMB_ADDRESS);
+        TokenQuotaParams memory tqp = pqk.tokenQuotaParams(DUMB_ADDRESS);
 
-        assertEq(totalQuoted, 0, "totalQuoted !=0");
-        assertEq(limit, 0, "limit !=0");
-        assertEq(rate, 0, "rate !=0");
-        assertEq(cumulativeIndexLU_RAY, 1, "Cumulative index !=1");
-    }
-
-    /// @notice U:[PQK-6]: addQuotaToken reverts on adding quoted token or underlying
-    function test_U_PQK_06_addQuotaToken_reverts_on_adding_quoted_token_or_underlying() public {
-        address gauge = pqk.gauge();
-        vm.prank(gauge);
-        pqk.addQuotaToken(DUMB_ADDRESS);
+        assertEq(tqp.totalQuoted, 0, "totalQuoted !=0");
+        assertEq(tqp.limit, 0, "limit !=0");
+        assertEq(tqp.rate, 0, "rate !=0");
+        assertEq(tqp.cumulativeIndexLU, 0, "Cumulative index !=1");
 
         vm.prank(gauge);
         vm.expectRevert(TokenAlreadyAddedException.selector);
         pqk.addQuotaToken(DUMB_ADDRESS);
-
-        vm.prank(gauge);
-        vm.expectRevert(TokenNotAllowedException.selector);
-        pqk.addQuotaToken(underlying);
     }
 
-    /// @notice U:[PQK-7]: updateRates works as expected
-    function test_U_PQK_07_updateRates_works_as_expected() public {
+    /// @notice U:[QK-6]: updateRates works as expected
+    function test_U_QK_06_updateRates_works_as_expected() public {
         address DAI = tokenTestSuite.addressOf(Tokens.DAI);
         address USDC = tokenTestSuite.addressOf(Tokens.USDC);
 
@@ -221,7 +215,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
                 pqk.updateQuota({
                     creditAccount: DUMB_ADDRESS,
                     token: DAI,
-                    requestedChange: daiQuota,
+                    quotaChange: daiQuota,
                     minQuota: 0,
                     maxQuota: type(uint96).max
                 });
@@ -230,7 +224,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
                 pqk.updateQuota({
                     creditAccount: DUMB_ADDRESS,
                     token: USDC,
-                    requestedChange: usdcQuota,
+                    quotaChange: usdcQuota,
                     minQuota: 0,
                     maxQuota: type(uint96).max
                 });
@@ -258,22 +252,21 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
             vm.prank(address(gaugeMock));
             pqk.updateRates();
 
-            (uint16 rate, uint192 cumulativeIndexLU_RAY,, uint96 totalQuoted, uint96 limit,) =
-                pqk.getTokenQuotaParams(DAI);
+            TokenQuotaParams memory tqp = pqk.tokenQuotaParams(DAI);
 
-            assertEq(rate, DAI_QUOTA_RATE, _testCaseErr("Incorrect DAI rate"));
+            assertEq(tqp.rate, DAI_QUOTA_RATE, _testCaseErr("Incorrect DAI rate"));
             assertEq(
-                cumulativeIndexLU_RAY,
-                1 + RAY * DAI_QUOTA_RATE / PERCENTAGE_FACTOR,
+                tqp.cumulativeIndexLU,
+                RAY * DAI_QUOTA_RATE / PERCENTAGE_FACTOR,
                 _testCaseErr("Incorrect DAI cumulativeIndexLU")
             );
 
-            (rate, cumulativeIndexLU_RAY,, totalQuoted, limit,) = pqk.getTokenQuotaParams(USDC);
+            tqp = pqk.tokenQuotaParams(USDC);
 
-            assertEq(rate, USDC_QUOTA_RATE, _testCaseErr("Incorrect USDC rate"));
+            assertEq(tqp.rate, USDC_QUOTA_RATE, _testCaseErr("Incorrect USDC rate"));
             assertEq(
-                cumulativeIndexLU_RAY,
-                1 + RAY * USDC_QUOTA_RATE / PERCENTAGE_FACTOR,
+                tqp.cumulativeIndexLU,
+                RAY * USDC_QUOTA_RATE / PERCENTAGE_FACTOR,
                 _testCaseErr("Incorrect USDC cumulativeIndexLU")
             );
 
@@ -283,8 +276,8 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         }
     }
 
-    /// @notice U:[PQK-8]: setGauge works as expected
-    function test_U_PQK_08_setGauge_works_as_expected() public {
+    /// @notice U:[QK-7]: setGauge works as expected
+    function test_U_QK_07_setGauge_works_as_expected() public {
         pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(poolMock));
 
         assertEq(pqk.gauge(), address(0), "SETUP: incorrect address at start");
@@ -300,27 +293,24 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
 
         pqk.setGauge(address(gaugeMock));
         assertEq(pqk.gauge(), address(gaugeMock), "gauge address wasnt updated");
+
+        vm.prank(address(gaugeMock));
+        pqk.addQuotaToken(makeAddr("TOKEN"));
+
+        vm.expectRevert(TokenIsNotQuotedException.selector);
+        pqk.setGauge(address(gaugeMock));
     }
 
-    /// @notice U:[PQK-9]: addCreditManager works as expected
-    function test_U_PQK_09_addCreditManager_reverts_for_non_cm_contract() public {
-        // Case: non registered credit manager
-        vm.expectRevert(RegisteredCreditManagerOnlyException.selector);
-        pqk.addCreditManager(DUMB_ADDRESS);
-
-        // Case: credit manager with different poolMock address
-        creditManagerMock.setPoolService(DUMB_ADDRESS);
-        vm.expectRevert(IncompatibleCreditManagerException.selector);
-        pqk.addCreditManager(address(creditManagerMock));
-    }
-
-    /// @notice U:[PQK-10]: addCreditManager works as expected
-    function test_U_PQK_10_addCreditManager_works_as_expected() public {
+    /// @notice U:[QK-8]: addCreditManager works as expected
+    function test_U_QK_08_addCreditManager_works_as_expected() public {
         pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(poolMock));
 
         address[] memory managers = pqk.creditManagers();
-
         assertEq(managers.length, 0, "SETUP: at least one creditmanager is unexpectedly connected");
+
+        // Case: non registered credit manager
+        vm.expectRevert(RegisteredCreditManagerOnlyException.selector);
+        pqk.addCreditManager(DUMB_ADDRESS);
 
         vm.expectEmit(true, true, false, false);
         emit AddCreditManager(address(creditManagerMock));
@@ -337,16 +327,21 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         managers = pqk.creditManagers();
         assertEq(managers.length, 1, "Incorrect length of connected managers");
         assertEq(managers[0], address(creditManagerMock), "Incorrect address was added to creditManagerSet");
+
+        // Case: credit manager with different poolMock address
+        creditManagerMock.setPoolService(DUMB_ADDRESS);
+        vm.expectRevert(IncompatibleCreditManagerException.selector);
+        pqk.addCreditManager(address(creditManagerMock));
     }
 
-    /// @notice U:[PQK-11]: setTokenLimit reverts for unregistered token
-    function test_U_PQK_11_reverts_for_unregistered_token() public {
+    /// @notice U:[QK-9]: setTokenLimit works as expected
+    function test_U_QK_09_setTokenLimit_works_as_expected() public {
+        vm.expectRevert(IncorrectParameterException.selector);
+        pqk.setTokenLimit(DUMB_ADDRESS, type(uint96).max);
+
         vm.expectRevert(TokenIsNotQuotedException.selector);
         pqk.setTokenLimit(DUMB_ADDRESS, 1);
-    }
 
-    /// @notice U:[PQK-12]: setTokenLimit works as expected
-    function test_U_PQK_12_setTokenLimit_works_as_expected() public {
         uint96 limit = 435_223_999;
 
         gaugeMock.addQuotaToken(DUMB_ADDRESS, 11);
@@ -356,22 +351,22 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
 
         pqk.setTokenLimit(DUMB_ADDRESS, limit);
 
-        (,,,, uint96 limitSet, bool isActive) = pqk.getTokenQuotaParams(DUMB_ADDRESS);
+        TokenQuotaParams memory tqp = pqk.tokenQuotaParams(DUMB_ADDRESS);
 
-        assertEq(limitSet, limit, "Incorrect limit was set");
-        assertTrue(!isActive, "Incorrect isActive was set");
+        assertEq(tqp.limit, limit, "Incorrect limit was set");
+        assertEq(tqp.rate, 0, "Rate is incorrectly non-zero");
 
         vm.warp(block.timestamp + 7 days);
         gaugeMock.updateEpoch();
 
-        (,,,, limitSet, isActive) = pqk.getTokenQuotaParams(DUMB_ADDRESS);
+        tqp = pqk.tokenQuotaParams(DUMB_ADDRESS);
 
-        assertEq(limitSet, limit, "Incorrect limit was set");
-        assertTrue(isActive, "Incorrect isActive was set");
+        assertEq(tqp.limit, limit, "Incorrect limit was set");
+        assertNotEq(tqp.rate, 0, "Rate is incorrectly zero");
     }
 
-    /// @notice U:[PQK-13]: setTokenQuotaIncreaseFee works as expected
-    function test_U_PQK_13_setTokenQuotaIncreaseFee_works_as_expected() public {
+    /// @notice U:[QK-10]: setTokenQuotaIncreaseFee works as expected
+    function test_U_QK_10_setTokenQuotaIncreaseFee_works_as_expected() public {
         uint16 fee = 39_99;
 
         gaugeMock.addQuotaToken(DUMB_ADDRESS, 11);
@@ -381,23 +376,35 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
 
         pqk.setTokenQuotaIncreaseFee(DUMB_ADDRESS, fee);
 
-        (,, uint16 feeSet,,,) = pqk.getTokenQuotaParams(DUMB_ADDRESS);
+        TokenQuotaParams memory tqp = pqk.tokenQuotaParams(DUMB_ADDRESS);
 
-        assertEq(feeSet, fee, "Incorrect fee was set");
+        assertEq(tqp.quotaIncreaseFee, fee, "Incorrect fee was set");
     }
 
-    /// @notice U:[PQK-14]: updateQuota reverts for unregistered token
-    function test_U_PQK_14_updateQuotas_reverts_for_unregistered_token() public {
+    /// @notice U:[QK-11]: updateQuota reverts for unregistered token
+    function test_U_QK_11_updateQuotas_reverts_for_unregistered_token() public {
         pqk.addCreditManager(address(creditManagerMock));
-
         address link = tokenTestSuite.addressOf(Tokens.LINK);
-        vm.expectRevert(TokenIsNotQuotedException.selector);
 
+        vm.expectRevert(TokenIsNotQuotedException.selector);
         vm.prank(address(creditManagerMock));
         pqk.updateQuota({
             creditAccount: DUMB_ADDRESS,
             token: link,
-            requestedChange: -int96(uint96(100 * WAD)),
+            quotaChange: -int96(uint96(100 * WAD)),
+            minQuota: 0,
+            maxQuota: 1
+        });
+
+        vm.prank(address(gaugeMock));
+        pqk.addQuotaToken(link);
+
+        vm.expectRevert(TokenIsNotQuotedException.selector);
+        vm.prank(address(creditManagerMock));
+        pqk.updateQuota({
+            creditAccount: DUMB_ADDRESS,
+            token: link,
+            quotaChange: -int96(uint96(100 * WAD)),
             minQuota: 0,
             maxQuota: 1
         });
@@ -420,9 +427,9 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         int256 expectedQuotaRevenueChange;
     }
 
-    /// @notice U:[PQK-15]: updateQuotas works as expected
-    function test_U_PQK_15_updateQuotas_works_as_expected() public {
-        UpdateQuotaTestCase[7] memory cases = [
+    /// @notice U:[QK-12]: updateQuotas works as expected
+    function test_U_QK_12_updateQuotas_works_as_expected() public {
+        UpdateQuotaTestCase[6] memory cases = [
             UpdateQuotaTestCase({
                 name: "Open new quota < limit",
                 /// SETUP
@@ -438,22 +445,6 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
                 expectedDisableToken: false,
                 expectRevert: false,
                 expectedQuotaRevenueChange: 10_000 * 10 / 100 // 10% additional rate
-            }),
-            UpdateQuotaTestCase({
-                name: "Quota in a year",
-                /// SETUP
-                period: 365 days,
-                change: 0,
-                minQuota: 0,
-                maxQuota: 100_000_000,
-                /// 10_000 * 10% quota
-                expectedCaQuotaInterestChange: 1_000,
-                expectedFees: 0,
-                expectedRealQuotaChange: 0,
-                expectedEnableToken: false,
-                expectedDisableToken: false,
-                expectRevert: false,
-                expectedQuotaRevenueChange: 0
             }),
             UpdateQuotaTestCase({
                 name: "Quota < minQuota",
@@ -611,8 +602,8 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         int256 expectedRevenueChange;
     }
 
-    /// @notice U:[PQK-16]: removeQuotas works correctly
-    function test_U_PQK_16_removeQuotas_works_correctly() public {
+    /// @notice U:[QK-13]: removeQuotas works correctly
+    function test_U_QK_13_removeQuotas_works_correctly() public {
         RemoveQuotasCase[4] memory cases = [
             RemoveQuotasCase({
                 token1Quota: 1,
@@ -674,7 +665,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
             pqk.updateQuota({
                 creditAccount: creditAccount,
                 token: token1,
-                requestedChange: int96(cases[i].token1Quota),
+                quotaChange: int96(cases[i].token1Quota),
                 minQuota: 0,
                 maxQuota: type(uint96).max
             });
@@ -683,7 +674,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
             pqk.updateQuota({
                 creditAccount: creditAccount,
                 token: token2,
-                requestedChange: int96(cases[i].token2Quota),
+                quotaChange: int96(cases[i].token2Quota),
                 minQuota: 0,
                 maxQuota: type(uint96).max
             });
@@ -692,7 +683,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
             pqk.updateQuota({
                 creditAccount: DUMB_ADDRESS,
                 token: token1,
-                requestedChange: int96(cases[i].token1TotalQuoted - cases[i].token1Quota),
+                quotaChange: int96(cases[i].token1TotalQuoted - cases[i].token1Quota),
                 minQuota: 0,
                 maxQuota: type(uint96).max
             });
@@ -701,7 +692,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
             pqk.updateQuota({
                 creditAccount: DUMB_ADDRESS,
                 token: token2,
-                requestedChange: int96(cases[i].token2TotalQuoted - cases[i].token2Quota),
+                quotaChange: int96(cases[i].token2TotalQuoted - cases[i].token2Quota),
                 minQuota: 0,
                 maxQuota: type(uint96).max
             });
@@ -734,25 +725,29 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
                 assertEq(quota2, 0, "Quota 2 was not removed");
             }
 
-            (,,, uint96 totalQuoted1, uint96 limit1,) = pqk.getTokenQuotaParams(token1);
-            (,,, uint96 totalQuoted2, uint96 limit2,) = pqk.getTokenQuotaParams(token2);
+            TokenQuotaParams memory tqp1 = pqk.tokenQuotaParams(token1);
+            TokenQuotaParams memory tqp2 = pqk.tokenQuotaParams(token2);
 
-            assertEq(totalQuoted1, cases[i].token1TotalQuoted - cases[i].token1Quota, "Incorrect new total quoted 1");
+            assertEq(
+                tqp1.totalQuoted, cases[i].token1TotalQuoted - cases[i].token1Quota, "Incorrect new total quoted 1"
+            );
 
-            assertEq(totalQuoted2, cases[i].token2TotalQuoted - cases[i].token2Quota, "Incorrect new total quoted 2");
+            assertEq(
+                tqp2.totalQuoted, cases[i].token2TotalQuoted - cases[i].token2Quota, "Incorrect new total quoted 2"
+            );
 
             if (cases[i].setLimitsToZero) {
-                assertEq(limit1, 0, "Limit 1 was not set to zero");
+                assertEq(tqp1.limit, 0, "Limit 1 was not set to zero");
 
-                assertEq(limit2, 0, "Limit 2 was not set to zero");
+                assertEq(tqp2.limit, 0, "Limit 2 was not set to zero");
             }
 
             vm.revertTo(snapshot);
         }
     }
 
-    /// @notice U:[PQK-17]: accrueQuotaInterest works correctly
-    function test_U_PQK_17_accrueQuotaInterest_works_correctly() external {
+    /// @notice U:[QK-14]: accrueQuotaInterest works correctly
+    function test_U_QK_14_accrueQuotaInterest_works_correctly() external {
         pqk.addCreditManager(address(creditManagerMock));
 
         address creditAccount = makeAddr("CREDIT_ACCOUNT");
@@ -783,7 +778,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         pqk.updateQuota({
             creditAccount: creditAccount,
             token: token1,
-            requestedChange: int96(uint96(WAD)),
+            quotaChange: int96(uint96(WAD)),
             minQuota: 0,
             maxQuota: type(uint96).max
         });
@@ -792,7 +787,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         pqk.updateQuota({
             creditAccount: creditAccount,
             token: token2,
-            requestedChange: int96(uint96(WAD)),
+            quotaChange: int96(uint96(WAD)),
             minQuota: 0,
             maxQuota: type(uint96).max
         });
@@ -800,17 +795,14 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper, IPoolQuotaKeepe
         uint256 timestampLU = block.timestamp;
         vm.warp(block.timestamp + 365 days);
 
-        uint192 expectedIndex1 = QuotasLogic.cumulativeIndexSince(1, 1000, timestampLU);
+        uint192 expectedIndex1 = QuotasLogic.cumulativeIndexSince(0, 1000, timestampLU);
         // uint192 expectedIndex2 = QuotasLogic.cumulativeIndexSince(uint192(RAY), 2000, timestampLU);
 
         vm.prank(address(creditManagerMock));
         pqk.accrueQuotaInterest(creditAccount, tokens);
 
-        (, uint192 actualIndex1) = pqk.getQuota(creditAccount, token1);
-        // (, uint192 actualIndex2) = pqk.getQuota(creditAccount, token2);
+        assertEq(pqk.accountQuotas(creditAccount, token1).cumulativeIndexLU, expectedIndex1, "Incorrect token 1 index");
 
-        assertEq(expectedIndex1, actualIndex1, "Incorrect token 1 index");
-
-        assertEq(expectedIndex1, actualIndex1, "Incorrect token 2 index");
+        // assertEq(pqk.accountQuotas(creditAccount, token2).cumulativeIndexLU, expectedIndex2, "Incorrect token 2 index");
     }
 }

--- a/contracts/test/unit/pool/PoolV3Harness.sol
+++ b/contracts/test/unit/pool/PoolV3Harness.sol
@@ -76,6 +76,10 @@ contract PoolV3Harness is PoolV3 {
     // QUOTAS //
     // ------ //
 
+    function hackQuotaKeeper(address quotaKeeper) external {
+        _quotaKeeper = quotaKeeper;
+    }
+
     function hackQuotaRevenue(uint256 value) external {
         _quotaRevenue = uint96(value);
         lastQuotaRevenueUpdate = uint40(block.timestamp);

--- a/contracts/test/unit/pool/TumblerV3.unit.t.sol
+++ b/contracts/test/unit/pool/TumblerV3.unit.t.sol
@@ -40,16 +40,17 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
         poolQuotaKeeper.set_lastQuotaRateUpdate(uint40(block.timestamp));
         pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
 
-        tumbler = new TumblerV3(address(addressProvider), address(pool), 1 days);
+        tumbler = new TumblerV3(address(addressProvider), address(poolQuotaKeeper), 1 days);
     }
 
     /// @notice U:[TU-1]: Constructor works as expected
     function test_U_TU_01_constructor_works_as_expected() public {
-        assertEq(tumbler.pool(), address(pool), "Incorrect pool");
-        assertEq(tumbler.underlying(), underlying, "Incorrect underlying");
-        assertEq(tumbler.poolQuotaKeeper(), address(poolQuotaKeeper), "Incorrect poolQuotaKeeper");
+        assertEq(tumbler.quotaKeeper(), address(poolQuotaKeeper), "Incorrect quotaKeeper");
         assertEq(tumbler.epochLength(), 1 days, "Incorrect epochLength");
         assertEq(tumbler.getTokens().length, 0, "Non-empty quoted tokens set");
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new TumblerV3(address(addressProvider), address(0), 1 days);
     }
 
     /// @notice U:[TU-2]: `addToken` works as expected
@@ -62,11 +63,7 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
 
         // addToken reverts if token is zero address
         vm.expectRevert(ZeroAddressException.selector);
-        tumbler.addToken(address(0), 0);
-
-        // addToken reverts if token is underlying
-        vm.expectRevert(TokenNotAllowedException.selector);
-        tumbler.addToken(underlying, 0);
+        tumbler.addToken(address(0), 1);
 
         // addToken properly adds token to both rate and quota keeper and sets rate
         poolQuotaKeeper.set_isQuotedToken(false);
@@ -87,7 +84,7 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
 
         // addToken reverts if token is already added
         vm.expectRevert(TokenNotAllowedException.selector);
-        tumbler.addToken(token1, 0);
+        tumbler.addToken(token1, 1);
 
         // addToken adds token to tumbler but skips quota keeper if token is already there
         poolQuotaKeeper.set_isQuotedToken(true);
@@ -97,7 +94,10 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
         vm.expectEmit(true, true, true, true);
         emit AddToken(token2);
 
-        tumbler.addToken(token2, 0);
+        vm.expectEmit(true, true, true, true);
+        emit SetRate(token2, 1);
+
+        tumbler.addToken(token2, 1);
 
         quotedTokens = tumbler.getTokens();
         assertEq(quotedTokens.length, 2, "Incorrect getTokens.length");
@@ -112,9 +112,9 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
 
         // setRate reverts if token is not added
         vm.expectRevert(TokenIsNotQuotedException.selector);
-        tumbler.setRate(token1, 0);
+        tumbler.setRate(token1, 1);
 
-        tumbler.addToken(token1, 0);
+        tumbler.addToken(token1, 1);
 
         // setRate reverts on zero rate
         vm.expectRevert(IncorrectParameterException.selector);

--- a/contracts/test/unit/pool/TumblerV3.unit.t.sol
+++ b/contracts/test/unit/pool/TumblerV3.unit.t.sol
@@ -78,6 +78,8 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
 
         tumbler.addToken(token1, 4200);
 
+        assertTrue(tumbler.isTokenAdded(token1), "token1 is not added");
+
         address[] memory quotedTokens = tumbler.getTokens();
         assertEq(quotedTokens.length, 1, "Incorrect getTokens.length");
         assertEq(quotedTokens[0], token1, "Incorrect getTokens[0]");
@@ -98,6 +100,8 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
         emit SetRate(token2, 1);
 
         tumbler.addToken(token2, 1);
+
+        assertTrue(tumbler.isTokenAdded(token2), "token2 is not added");
 
         quotedTokens = tumbler.getTokens();
         assertEq(quotedTokens.length, 2, "Incorrect getTokens.length");


### PR DESCRIPTION
In this PR:
* Significant quota keeper refactoring which makes the code much easier to reason about
* `PoolV3.setPoolQuotaKeeper` now only exists to initialize the quota keeper, which allows to make it immutable in the credit manager and gauges
* Quota keeper performs more validation of the gauge that is connected to it
* Quota keeper now explicitly prevents underlying from being added as quoted token, while facade prevents users from purchasing quota for underlying