### PR TITLE
feat: loss liquidator

### DIFF
--- a/contracts/interfaces/ICreditConfiguratorV3.sol
+++ b/contracts/interfaces/ICreditConfiguratorV3.sol
@@ -79,14 +79,11 @@ interface ICreditConfiguratorV3Events {
     /// @notice Emitted when a new max debt per block multiplier is set
     event SetMaxDebtPerBlockMultiplier(uint8 maxDebtPerBlockMultiplier);
 
-    /// @notice Emitted when a new max cumulative loss is set
-    event SetMaxCumulativeLoss(uint128 maxCumulativeLoss);
-
-    /// @notice Emitted when cumulative loss is reset to zero in the credit facade
-    event ResetCumulativeLoss();
-
     /// @notice Emitted when a new expiration timestamp is set in the credit facade
     event SetExpirationDate(uint40 expirationDate);
+
+    /// @notice Emitted when new loss liquidator is set
+    event SetLossLiquidator(address indexed liquidator);
 
     /// @notice Emitted when an address is added to the list of emergency liquidators
     event AddEmergencyLiquidator(address indexed liquidator);
@@ -165,11 +162,9 @@ interface ICreditConfiguratorV3 is IACLTrait, IVersion, ICreditConfiguratorV3Eve
 
     function forbidBorrowing() external;
 
-    function setMaxCumulativeLoss(uint128 newMaxCumulativeLoss) external;
-
-    function resetCumulativeLoss() external;
-
     function setExpirationDate(uint40 newExpirationDate) external;
+
+    function setLossLiquidator(address newLossLiquidator) external;
 
     function addEmergencyLiquidator(address liquidator) external;
 

--- a/contracts/interfaces/ICreditFacadeV3.sol
+++ b/contracts/interfaces/ICreditFacadeV3.sol
@@ -25,14 +25,6 @@ struct DebtLimits {
     uint128 maxDebt;
 }
 
-/// @notice Info on bad debt liquidation losses packed into a single slot
-/// @param currentCumulativeLoss Current cumulative loss from bad debt liquidations
-/// @param maxCumulativeLoss Max cumulative loss incurred before the facade gets paused
-struct CumulativeLossParams {
-    uint128 currentCumulativeLoss;
-    uint128 maxCumulativeLoss;
-}
-
 /// @notice Collateral check params
 /// @param collateralHints Optional array of token masks to check first to reduce the amount of computation
 ///        when known subset of account's collateral tokens covers all the debt
@@ -106,9 +98,9 @@ interface ICreditFacadeV3 is IACLTrait, IVersion, ICreditFacadeV3Events {
 
     function debtLimits() external view returns (uint128 minDebt, uint128 maxDebt);
 
-    function lossParams() external view returns (uint128 currentCumulativeLoss, uint128 maxCumulativeLoss);
-
     function forbiddenTokenMask() external view returns (uint256);
+
+    function lossLiquidator() external view returns (address);
 
     function emergencyLiquidators() external view returns (address[] memory);
 
@@ -125,7 +117,9 @@ interface ICreditFacadeV3 is IACLTrait, IVersion, ICreditFacadeV3Events {
 
     function closeCreditAccount(address creditAccount, MultiCall[] calldata calls) external payable;
 
-    function liquidateCreditAccount(address creditAccount, address to, MultiCall[] calldata calls) external;
+    function liquidateCreditAccount(address creditAccount, address to, MultiCall[] calldata calls)
+        external
+        returns (uint256 reportedLoss);
 
     function partiallyLiquidateCreditAccount(
         address creditAccount,
@@ -148,9 +142,9 @@ interface ICreditFacadeV3 is IACLTrait, IVersion, ICreditFacadeV3Events {
 
     function setDebtLimits(uint128 newMinDebt, uint128 newMaxDebt, uint8 newMaxDebtPerBlockMultiplier) external;
 
-    function setCumulativeLossParams(uint128 newMaxCumulativeLoss, bool resetCumulativeLoss) external;
-
     function setTokenAllowance(address token, AllowanceAction allowance) external;
+
+    function setLossLiquidator(address newLossLiquidator) external;
 
     function setEmergencyLiquidator(address liquidator, AllowanceAction allowance) external;
 }

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -274,6 +274,9 @@ error CallerNotExecutorException();
 /// @notice Thrown on attempting to call an access restricted function not as veto admin
 error CallerNotVetoAdminException();
 
+/// @notice Thrown on attempting to perform liquidation with loss not through the loss liquidator contract
+error CallerNotLossLiquidatorException();
+
 // -------- //
 // BOT LIST //
 // -------- //

--- a/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
+++ b/contracts/test/integration/credit/LiquidateCreditAccount.int.t.sol
@@ -121,29 +121,6 @@ contract LiquidateCreditAccountIntegrationTest is IntegrationTestHelper, ICredit
         assertEq(maxDebtPerBlockMultiplier, 0, "Increase debt wasn't forbidden after loss");
     }
 
-    /// @dev I:[LCA-5]: CreditFacade is paused after too much cumulative loss from liquidations
-    function test_I_LCA_05_liquidateCreditAccount_pauses_CreditFacade_on_too_much_loss()
-        public
-        withAdapterMock
-        creditTest
-    {
-        vm.prank(CONFIGURATOR);
-        creditConfigurator.setMaxCumulativeLoss(1);
-
-        (address creditAccount,) = _openTestCreditAccount();
-
-        MultiCall[] memory calls = MultiCallBuilder.build(
-            MultiCall({target: address(adapterMock), callData: abi.encodeCall(AdapterMock.dumbCall, ())})
-        );
-
-        _makeAccountsLiquitable();
-
-        vm.prank(LIQUIDATOR);
-        creditFacade.liquidateCreditAccount(creditAccount, FRIEND, calls);
-
-        assertTrue(creditFacade.paused(), "Credit manager was not paused");
-    }
-
     /// @dev I:[LCA-6]: liquidateCreditAccount reverts on internal call in multicall on closure
     function test_I_LCA_06_liquidateCreditAccount_reverts_on_internal_call_in_multicall_on_closure()
         public

--- a/contracts/test/unit/credit/CreditFacadeV3Harness.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3Harness.sol
@@ -22,10 +22,6 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
         _reentrancyStatus = _status;
     }
 
-    function setCumulativeLoss(uint128 newLoss) external {
-        lossParams.currentCumulativeLoss = newLoss;
-    }
-
     function multicallInt(address creditAccount, MultiCall[] calldata calls, uint256 enabledTokensMask, uint256 flags)
         external
     {
@@ -62,9 +58,5 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
 
     function isExpired() external view returns (bool) {
         return _isExpired();
-    }
-
-    function setCurrentCumulativeLoss(uint128 _currentCumulativeLoss) external {
-        lossParams.currentCumulativeLoss = _currentCumulativeLoss;
     }
 }


### PR DESCRIPTION
In this PR:
* liquidations with loss now should go through the special loss liquidator contract (out of scope of this repo)
* credit facade is no longer paused on hitting cumulative loss threshold and related parameters are removed
* `liquidateCreditAccount` returns reported loss since after removal of cumulative loss there's no simple way to tell whether any loss occurred