### PR TITLE
feat: revise ACL-related traits and roles for emergency-related functions

### DIFF
--- a/contracts/core/PriceOracleV3.sol
+++ b/contracts/core/PriceOracleV3.sol
@@ -17,8 +17,9 @@ import {
 import {IPriceOracleV3, PriceFeedParams, PriceUpdate} from "../interfaces/IPriceOracleV3.sol";
 import {IUpdatablePriceFeed} from "../interfaces/base/IPriceFeed.sol";
 
-import {ACLTrait} from "../traits/ACLTrait.sol";
+import {ControlledTrait} from "../traits/ControlledTrait.sol";
 import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
+import {SanityCheckTrait} from "../traits/SanityCheckTrait.sol";
 
 /// @title  Price oracle V3
 /// @notice Acts as router that dispatches calls to corresponding price feeds.
@@ -33,7 +34,7 @@ import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
 ///         not be used for general collateral evaluation, including decisions on whether accounts are liquidatable.
 ///         - Finally, this contract serves as register for updatable price feeds and can be used to apply batched
 ///         on-demand price updates while ensuring that those are not calls to arbitrary contracts.
-contract PriceOracleV3 is ACLTrait, PriceFeedValidationTrait, IPriceOracleV3 {
+contract PriceOracleV3 is ControlledTrait, PriceFeedValidationTrait, SanityCheckTrait, IPriceOracleV3 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @notice Contract version
@@ -53,7 +54,7 @@ contract PriceOracleV3 is ACLTrait, PriceFeedValidationTrait, IPriceOracleV3 {
 
     /// @notice Constructor
     /// @param  acl_ ACL contract address
-    constructor(address acl_) ACLTrait(acl_) {}
+    constructor(address acl_) ControlledTrait(acl_) {}
 
     /// @notice Returns all tokens that have price feeds
     function getTokens() external view override returns (address[] memory) {

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -24,8 +24,9 @@ import {IPriceOracleV3} from "../interfaces/IPriceOracleV3.sol";
 import {IAdapter} from "../interfaces/base/IAdapter.sol";
 
 // TRAITS
-import {ACLTrait} from "../traits/ACLTrait.sol";
+import {ControlledTrait} from "../traits/ControlledTrait.sol";
 import {ReentrancyGuardTrait} from "../traits/ReentrancyGuardTrait.sol";
+import {SanityCheckTrait} from "../traits/SanityCheckTrait.sol";
 
 // EXCEPTIONS
 import "../interfaces/IExceptions.sol";
@@ -33,7 +34,7 @@ import "../interfaces/IExceptions.sol";
 /// @title Credit configurator V3
 /// @notice Provides funcionality to configure various aspects of credit manager and facade's behavior
 /// @dev Most of the functions can only be accessed by configurator or timelock controller
-contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLTrait, ReentrancyGuardTrait {
+contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, ReentrancyGuardTrait, SanityCheckTrait {
     using EnumerableSet for EnumerableSet.AddressSet;
     using Address for address;
     using BitMask for uint256;
@@ -63,7 +64,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLTrait, ReentrancyGuar
     /// @param _acl ACL contract address
     /// @param _creditManager Credit manager to connect to
     /// @dev Copies allowed adaprters from the currently connected configurator
-    constructor(address _acl, address _creditManager) ACLTrait(_acl) {
+    constructor(address _acl, address _creditManager) ControlledTrait(_acl) {
         creditManager = _creditManager; // I:[CC-1]
         underlying = CreditManagerV3(_creditManager).underlying(); // I:[CC-1]
 

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -674,7 +674,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, Reentra
     function removeEmergencyLiquidator(address liquidator)
         external
         override
-        configuratorOnly // I:[CC-2]
+        controllerOrConfiguratorOnly // I:[CC-2B]
     {
         CreditFacadeV3 cf = CreditFacadeV3(creditFacade());
 

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.23;
 
 // THIRD-PARTY
 import {SafeERC20} from "@1inch/solidity-utils/contracts/libraries/SafeERC20.sol";
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
@@ -58,7 +59,7 @@ import {ReentrancyGuardTrait} from "../traits/ReentrancyGuardTrait.sol";
 ///         - policies on how liquidations with loss are performed
 ///         - forbidden tokens (they count towards account value, but having them enabled as collateral restricts allowed
 ///         actions and triggers a safer version of collateral check, incentivizing users to decrease exposure to them).
-contract CreditFacadeV3 is ICreditFacadeV3, ACLTrait, ReentrancyGuardTrait {
+contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardTrait {
     using Address for address;
     using BitMask for uint256;
     using SafeERC20 for IERC20;
@@ -838,6 +839,20 @@ contract CreditFacadeV3 is ICreditFacadeV3, ACLTrait, ReentrancyGuardTrait {
         } else {
             _emergencyLiquidatorsSet.remove(liquidator);
         } // U:[FA-53]
+    }
+
+    /// @notice Pauses contract
+    /// @dev Reverts if caller is not a pausable admin
+    /// @dev Reverts if contract is already paused
+    function pause() external override pausableAdminsOnly {
+        _pause();
+    }
+
+    /// @notice Unpauses contract
+    /// @dev Reverts if caller is not an unpausable admin
+    /// @dev Reverts if contract is already unpaused
+    function unpause() external override unpausableAdminsOnly {
+        _unpause();
     }
 
     // --------- //

--- a/contracts/interfaces/ICreditConfiguratorV3.sol
+++ b/contracts/interfaces/ICreditConfiguratorV3.sol
@@ -3,7 +3,7 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {IACLTrait} from "./base/IACLTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IVersion} from "./base/IVersion.sol";
 
 enum AllowanceAction {
@@ -12,7 +12,7 @@ enum AllowanceAction {
 }
 
 /// @title Credit configurator V3 interface
-interface ICreditConfiguratorV3 is IACLTrait, IVersion {
+interface ICreditConfiguratorV3 is IControlledTrait, IVersion {
     // ------ //
     // EVENTS //
     // ------ //

--- a/contracts/interfaces/ICreditFacadeV3.sol
+++ b/contracts/interfaces/ICreditFacadeV3.sol
@@ -153,4 +153,8 @@ interface ICreditFacadeV3 is IACLTrait, IVersion {
     function setLossLiquidator(address newLossLiquidator) external;
 
     function setEmergencyLiquidator(address liquidator, AllowanceAction allowance) external;
+
+    function pause() external;
+
+    function unpause() external;
 }

--- a/contracts/interfaces/IGaugeV3.sol
+++ b/contracts/interfaces/IGaugeV3.sol
@@ -3,7 +3,7 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {IACLTrait} from "./base/IACLTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IRateKeeper} from "./base/IRateKeeper.sol";
 import {IVotingContract} from "./base/IVotingContract.sol";
 
@@ -20,7 +20,7 @@ struct UserTokenVotes {
 }
 
 /// @title Gauge V3 interface
-interface IGaugeV3 is IACLTrait, IVotingContract, IRateKeeper {
+interface IGaugeV3 is IControlledTrait, IVotingContract, IRateKeeper {
     // ------ //
     // EVENTS //
     // ------ //

--- a/contracts/interfaces/IPoolQuotaKeeperV3.sol
+++ b/contracts/interfaces/IPoolQuotaKeeperV3.sol
@@ -3,8 +3,8 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {IACLTrait} from "./base/IACLTrait.sol";
 import {IContractsRegisterTrait} from "../interfaces/base/IContractsRegisterTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IVersion} from "./base/IVersion.sol";
 
 struct TokenQuotaParams {
@@ -21,7 +21,7 @@ struct AccountQuota {
 }
 
 /// @title Pool quota keeper V3 interface
-interface IPoolQuotaKeeperV3 is IACLTrait, IContractsRegisterTrait, IVersion {
+interface IPoolQuotaKeeperV3 is IControlledTrait, IContractsRegisterTrait, IVersion {
     // ------ //
     // EVENTS //
     // ------ //

--- a/contracts/interfaces/IPoolV3.sol
+++ b/contracts/interfaces/IPoolV3.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.8.23;
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import {IACLTrait} from "./base/IACLTrait.sol";
 import {IContractsRegisterTrait} from "../interfaces/base/IContractsRegisterTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IVersion} from "./base/IVersion.sol";
 
 /// @title Pool V3 interface
-interface IPoolV3 is IACLTrait, IContractsRegisterTrait, IVersion, IERC4626, IERC20Permit {
+interface IPoolV3 is IControlledTrait, IContractsRegisterTrait, IVersion, IERC4626, IERC20Permit {
     // ------ //
     // EVENTS //
     // ------ //
@@ -136,4 +136,8 @@ interface IPoolV3 is IACLTrait, IContractsRegisterTrait, IVersion, IERC4626, IER
     function setCreditManagerDebtLimit(address creditManager, uint256 newLimit) external;
 
     function setWithdrawFee(uint256 newWithdrawFee) external;
+
+    function pause() external;
+
+    function unpause() external;
 }

--- a/contracts/interfaces/IPriceOracleV3.sol
+++ b/contracts/interfaces/IPriceOracleV3.sol
@@ -3,7 +3,7 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {IACLTrait} from "./base/IACLTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IVersion} from "./base/IVersion.sol";
 
 /// @notice Price feed params
@@ -27,7 +27,7 @@ struct PriceUpdate {
 }
 
 /// @title Price oracle V3 interface
-interface IPriceOracleV3 is IACLTrait, IVersion {
+interface IPriceOracleV3 is IControlledTrait, IVersion {
     // ------ //
     // EVENTS //
     // ------ //

--- a/contracts/interfaces/ITumblerV3.sol
+++ b/contracts/interfaces/ITumblerV3.sol
@@ -3,11 +3,11 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {IACLTrait} from "./base/IACLTrait.sol";
+import {IControlledTrait} from "./base/IControlledTrait.sol";
 import {IRateKeeper} from "./base/IRateKeeper.sol";
 
 /// @title Tumbler V3 interface
-interface ITumblerV3 is IACLTrait, IRateKeeper {
+interface ITumblerV3 is IControlledTrait, IRateKeeper {
     // ------ //
     // EVENTS //
     // ------ //

--- a/contracts/interfaces/base/IACLTrait.sol
+++ b/contracts/interfaces/base/IACLTrait.sol
@@ -4,13 +4,5 @@
 pragma solidity ^0.8.23;
 
 interface IACLTrait {
-    /// @notice Emitted when new external controller is set
-    event NewController(address indexed newController);
-
     function acl() external view returns (address);
-    function controller() external view returns (address);
-    function setController(address) external;
-
-    function pause() external;
-    function unpause() external;
 }

--- a/contracts/interfaces/base/IControlledTrait.sol
+++ b/contracts/interfaces/base/IControlledTrait.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.23;
+
+import {IACLTrait} from "./IACLTrait.sol";
+
+interface IControlledTrait is IACLTrait {
+    /// @notice Emitted when new external controller is set
+    event NewController(address indexed newController);
+
+    function controller() external view returns (address);
+    function setController(address) external;
+}

--- a/contracts/pool/GaugeV3.sol
+++ b/contracts/pool/GaugeV3.sol
@@ -9,7 +9,8 @@ import {IPoolQuotaKeeperV3} from "../interfaces/IPoolQuotaKeeperV3.sol";
 
 import {EPOCH_LENGTH} from "../libraries/Constants.sol";
 
-import {ACLTrait} from "../traits/ACLTrait.sol";
+import {ControlledTrait} from "../traits/ControlledTrait.sol";
+import {SanityCheckTrait} from "../traits/SanityCheckTrait.sol";
 
 import "../interfaces/IExceptions.sol";
 
@@ -21,7 +22,7 @@ import "../interfaces/IExceptions.sol";
 ///         determined by the Gearbox DAO. GEAR holders then vote either for CA side, which moves the rate towards min,
 ///         or for LP side, which moves it towards max.
 ///         Rates are only updated once per epoch (1 week), to avoid manipulation and make strategies more predictable.
-contract GaugeV3 is IGaugeV3, ACLTrait {
+contract GaugeV3 is IGaugeV3, ControlledTrait, SanityCheckTrait {
     /// @notice Contract version
     uint256 public constant override version = 3_10;
 
@@ -59,7 +60,7 @@ contract GaugeV3 is IGaugeV3, ACLTrait {
     /// @dev    Reverts if any of `quotaKeeper_` or `gearStaking_` is zero address
     /// @custom:tests U:[GA-1]
     constructor(address acl_, address quotaKeeper_, address gearStaking_)
-        ACLTrait(acl_)
+        ControlledTrait(acl_)
         nonZeroAddress(quotaKeeper_)
         nonZeroAddress(gearStaking_)
     {

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -13,8 +13,8 @@ import {IRateKeeper} from "../interfaces/base/IRateKeeper.sol";
 import {PERCENTAGE_FACTOR} from "../libraries/Constants.sol";
 import {QuotasLogic} from "../libraries/QuotasLogic.sol";
 
-import {ACLTrait} from "../traits/ACLTrait.sol";
 import {ContractsRegisterTrait} from "../traits/ContractsRegisterTrait.sol";
+import {ControlledTrait} from "../traits/ControlledTrait.sol";
 
 import "../interfaces/IExceptions.sol";
 
@@ -26,7 +26,7 @@ import "../interfaces/IExceptions.sol";
 ///         * increase fee that is charged when additional quota is purchased (more suited to leveraged trading).
 ///         Quota keeper stores information about quotas of accounts in all credit managers connected to the pool, and
 ///         performs calculations that help to keep pool's expected liquidity and credit managers' debt consistent.
-contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ACLTrait, ContractsRegisterTrait {
+contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ControlledTrait, ContractsRegisterTrait {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @notice Contract version
@@ -79,7 +79,7 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ACLTrait, ContractsRegisterTra
     /// @param pool_ Pool address
     /// @custom:tests U:[QK-1]
     constructor(address acl_, address contractsRegister_, address pool_)
-        ACLTrait(acl_)
+        ControlledTrait(acl_)
         ContractsRegisterTrait(contractsRegister_)
     {
         pool = pool_;

--- a/contracts/pool/PoolV3.sol
+++ b/contracts/pool/PoolV3.sol
@@ -453,7 +453,6 @@ contract PoolV3 is
     function lendCreditAccount(uint256 borrowedAmount, address creditAccount)
         external
         override
-        whenNotPaused // U:[LP-2A]
         nonReentrant // U:[LP-2B]
         creditManagerOnly // U:[LP-2C]
     {
@@ -495,7 +494,6 @@ contract PoolV3 is
     function repayCreditAccount(uint256 repaidAmount, uint256 profit, uint256 loss)
         external
         override
-        whenNotPaused // U:[LP-2A]
         nonReentrant // U:[LP-2B]
         creditManagerOnly // U:[LP-2C]
     {

--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -7,14 +7,15 @@ import {IPoolQuotaKeeperV3} from "../interfaces/IPoolQuotaKeeperV3.sol";
 import {IPoolV3} from "../interfaces/IPoolV3.sol";
 import {ITumblerV3} from "../interfaces/ITumblerV3.sol";
 
-import {ACLTrait} from "../traits/ACLTrait.sol";
+import {ControlledTrait} from "../traits/ControlledTrait.sol";
+import {SanityCheckTrait} from "../traits/SanityCheckTrait.sol";
 
 import "../interfaces/IExceptions.sol";
 
 /// @title  Tumbler V3
 /// @notice Extremely simplified version of `GaugeV3` contract for quota rates management, which,
 ///         instead of voting, allows controller to set rates directly with custom epoch length
-contract TumblerV3 is ITumblerV3, ACLTrait {
+contract TumblerV3 is ITumblerV3, ControlledTrait, SanityCheckTrait {
     /// @notice Contract version
     uint256 public constant override version = 3_10;
 
@@ -35,7 +36,10 @@ contract TumblerV3 is ITumblerV3, ACLTrait {
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  epochLength_ Epoch length in seconds
     /// @custom:tests U:[TU-1]
-    constructor(address acl_, address quotaKeeper_, uint256 epochLength_) ACLTrait(acl_) nonZeroAddress(quotaKeeper_) {
+    constructor(address acl_, address quotaKeeper_, uint256 epochLength_)
+        ControlledTrait(acl_)
+        nonZeroAddress(quotaKeeper_)
+    {
         quotaKeeper = quotaKeeper_;
         epochLength = epochLength_;
     }

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -222,9 +222,6 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         creditConfigurator.addEmergencyLiquidator(address(0));
 
         vm.expectRevert(CallerNotConfiguratorException.selector);
-        creditConfigurator.removeEmergencyLiquidator(address(0));
-
-        vm.expectRevert(CallerNotConfiguratorException.selector);
         creditConfigurator.setExpirationDate(0);
 
         vm.stopPrank();
@@ -261,6 +258,9 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
 
         vm.expectRevert(CallerNotControllerOrConfiguratorException.selector);
         creditConfigurator.setMaxDebtPerBlockMultiplier(0);
+
+        vm.expectRevert(CallerNotControllerOrConfiguratorException.selector);
+        creditConfigurator.removeEmergencyLiquidator(address(0));
     }
 
     //

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -1023,7 +1023,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
 
     /// @dev I:[CC-28]: removeEmergencyLiquidator works correctly and emits event
     function test_I_CC_28_removeEmergencyLiquidator_works_correctly() public creditTest {
-        vm.expectRevert(CallerNotConfiguratorException.selector);
+        vm.expectRevert(CallerNotControllerOrConfiguratorException.selector);
         creditConfigurator.removeEmergencyLiquidator(DUMB_ADDRESS);
 
         vm.prank(CONFIGURATOR);

--- a/contracts/test/mocks/governance/GaugeMock.sol
+++ b/contracts/test/mocks/governance/GaugeMock.sol
@@ -30,7 +30,7 @@ contract GaugeMock is ACLTrait {
     //
 
     /// @dev Constructor
-    constructor(address acl, address quotaKeeper_) ACLTrait(acl) nonZeroAddress(quotaKeeper_) {
+    constructor(address acl, address quotaKeeper_) ACLTrait(acl) {
         quotaKeeper = quotaKeeper_;
     }
 

--- a/contracts/test/unit/pool/PoolV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolV3.unit.t.sol
@@ -213,12 +213,6 @@ contract PoolV3UnitTest is TestHelper {
 
         vm.expectRevert("Pausable: paused");
         pool.withdraw({assets: 1, owner: user, receiver: user});
-
-        vm.expectRevert("Pausable: paused");
-        pool.lendCreditAccount({borrowedAmount: 0, creditAccount: address(0)});
-
-        vm.expectRevert("Pausable: paused");
-        pool.repayCreditAccount({repaidAmount: 0, profit: 0, loss: 0});
     }
 
     /// @notice U:[LP-2B]: External functions revert on re-entrancy

--- a/contracts/traits/ContractsRegisterTrait.sol
+++ b/contracts/traits/ContractsRegisterTrait.sol
@@ -3,15 +3,17 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
-import {RegisteredCreditManagerOnlyException, RegisteredPoolOnlyException} from "../interfaces/IExceptions.sol";
+import {
+    AddressIsNotContractException,
+    RegisteredCreditManagerOnlyException,
+    RegisteredPoolOnlyException
+} from "../interfaces/IExceptions.sol";
 import {IContractsRegister} from "../interfaces/base/IContractsRegister.sol";
 import {IContractsRegisterTrait} from "../interfaces/base/IContractsRegisterTrait.sol";
 
-import {SanityCheckTrait} from "./SanityCheckTrait.sol";
-
-/// @title Contracts register trait
+/// @title  Contracts register trait
 /// @notice Trait that simplifies validation of pools and credit managers
-abstract contract ContractsRegisterTrait is IContractsRegisterTrait, SanityCheckTrait {
+abstract contract ContractsRegisterTrait is IContractsRegisterTrait {
     /// @notice Contracts register contract address
     address public immutable override contractsRegister;
 
@@ -28,9 +30,10 @@ abstract contract ContractsRegisterTrait is IContractsRegisterTrait, SanityCheck
     }
 
     /// @notice Constructor
-    /// @param _contractsRegister Contracts register address
-    constructor(address _contractsRegister) nonZeroAddress(_contractsRegister) {
-        contractsRegister = _contractsRegister;
+    /// @param  contractsRegister_ Contracts register contract address
+    constructor(address contractsRegister_) {
+        if (contractsRegister_.code.length == 0) revert AddressIsNotContractException(contractsRegister_);
+        contractsRegister = contractsRegister_;
     }
 
     /// @dev Ensures that given address is a registered pool

--- a/contracts/traits/ControlledTrait.sol
+++ b/contracts/traits/ControlledTrait.sol
@@ -16,15 +16,15 @@ abstract contract ControlledTrait is ACLTrait, IControlledTrait {
     /// @notice External controller address
     address public override controller;
 
-    /// @notice Constructor
-    /// @param  acl_ ACL contract address
-    constructor(address acl_) ACLTrait(acl_) {}
-
     /// @dev Ensures that function caller is external controller or configurator
     modifier controllerOrConfiguratorOnly() {
         _ensureCallerIsControllerOrConfigurator();
         _;
     }
+
+    /// @notice Constructor
+    /// @param  acl_ ACL contract address
+    constructor(address acl_) ACLTrait(acl_) {}
 
     /// @notice Sets new external controller, can only be called by configurator
     /// @dev    Reverts if `newController` is not a contract

--- a/contracts/traits/ControlledTrait.sol
+++ b/contracts/traits/ControlledTrait.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.23;
+
+import {
+    AddressIsNotContractException, CallerNotControllerOrConfiguratorException
+} from "../interfaces/IExceptions.sol";
+import {IControlledTrait} from "../interfaces/base/IControlledTrait.sol";
+
+import {ACLTrait} from "./ACLTrait.sol";
+
+/// @title  Controlled trait
+/// @notice Extended version of the ACL trait that introduces external controller role
+abstract contract ControlledTrait is ACLTrait, IControlledTrait {
+    /// @notice External controller address
+    address public override controller;
+
+    /// @notice Constructor
+    /// @param  acl_ ACL contract address
+    constructor(address acl_) ACLTrait(acl_) {}
+
+    /// @dev Ensures that function caller is external controller or configurator
+    modifier controllerOrConfiguratorOnly() {
+        _ensureCallerIsControllerOrConfigurator();
+        _;
+    }
+
+    /// @notice Sets new external controller, can only be called by configurator
+    /// @dev    Reverts if `newController` is not a contract
+    function setController(address newController) external override configuratorOnly {
+        if (controller == newController) return;
+        if (newController.code.length == 0) revert AddressIsNotContractException(newController);
+        controller = newController;
+        emit NewController(newController);
+    }
+
+    /// @dev Reverts if the caller is not controller or configurator
+    /// @dev Used to cut contract size on modifiers
+    function _ensureCallerIsControllerOrConfigurator() internal view {
+        if (msg.sender != controller && !_isConfigurator(msg.sender)) {
+            revert CallerNotControllerOrConfiguratorException();
+        }
+    }
+}


### PR DESCRIPTION
* optimize ACL-related traits:
  * `CreditFacadeV3` and `PoolV3` now implement pause/unpause themselves to avoid having these functions in contracts that can't really be paused
  *  `ACLTrait` is reduced to bare minimum, `ControlledTrait` is introduced for contracts that need external controller but without pausability overhead
* `PoolV3`'s `lendCreditAccount` and `repayCreditAccount` are no longer guarded with `whenNotPaused`
* `CreditConfiguratorV3.removeEmergencyLiquidator` can now be called by external controller