### PR TITLE
feat: deployment simplification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,12 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	tag = v1.9.1
 [submodule "lib/@gearbox-protocol/sdk-gov"]
 	path = lib/@gearbox-protocol/sdk-gov
 	url = https://github.com/Gearbox-protocol/sdk-gov
-	tag = v2.10.1
 [submodule "lib/@openzeppelin"]
 	path = lib/@openzeppelin
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	tag = v4.9.6
 [submodule "lib/@1inch/solidity-utils"]
 	path = lib/@1inch/solidity-utils
 	url = https://github.com/1inch/solidity-utils
-	tag = 2.4.0

--- a/contracts/core/AccountFactoryV3.sol
+++ b/contracts/core/AccountFactoryV3.sol
@@ -70,6 +70,7 @@ contract AccountFactoryV3 is IAccountFactoryV3, Ownable {
 
     /// @notice Constructor
     /// @param  owner_ Contract owner
+    /// @dev    Reverts if `owner_` is zero address
     constructor(address owner_) {
         transferOwnership(owner_);
     }

--- a/contracts/core/BotListV3.sol
+++ b/contracts/core/BotListV3.sol
@@ -42,6 +42,7 @@ contract BotListV3 is IBotListV3, Ownable {
 
     /// @notice Constructor
     /// @param  owner_ Contract owner
+    /// @dev    Reverts if `owner_` is zero address
     constructor(address owner_) {
         transferOwnership(owner_);
     }

--- a/contracts/core/GearStakingV3.sol
+++ b/contracts/core/GearStakingV3.sol
@@ -78,8 +78,9 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     /// @param  gear_ GEAR token address
     /// @param  firstEpochTimestamp_ Timestamp at which the first epoch should start.
     ///         Setting this too far into the future poses a risk of locking user deposits.
+    /// @dev    Reverts if any of `owner_` or `gear_` is zero address
     /// @custom:tests U:[GS-1]
-    constructor(address owner_, address gear_, uint256 firstEpochTimestamp_) {
+    constructor(address owner_, address gear_, uint256 firstEpochTimestamp_) nonZeroAddress(gear_) {
         gear = gear_;
         firstEpochTimestamp = firstEpochTimestamp_;
         transferOwnership(owner_);

--- a/contracts/core/PriceOracleV3.sol
+++ b/contracts/core/PriceOracleV3.sol
@@ -54,6 +54,7 @@ contract PriceOracleV3 is ControlledTrait, PriceFeedValidationTrait, SanityCheck
 
     /// @notice Constructor
     /// @param  acl_ ACL contract address
+    /// @dev    Reverts if `acl_` is zero address or is not a contract
     constructor(address acl_) ControlledTrait(acl_) {}
 
     /// @notice Returns all tokens that have price feeds

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -21,6 +21,7 @@ import {CreditManagerV3} from "./CreditManagerV3.sol";
 import {ICreditConfiguratorV3, AllowanceAction} from "../interfaces/ICreditConfiguratorV3.sol";
 import {IPoolQuotaKeeperV3} from "../interfaces/IPoolQuotaKeeperV3.sol";
 import {IPriceOracleV3} from "../interfaces/IPriceOracleV3.sol";
+import {IPoolV3} from "../interfaces/IPoolV3.sol";
 import {IAdapter} from "../interfaces/base/IAdapter.sol";
 import {IPhantomToken} from "../interfaces/base/IPhantomToken.sol";
 
@@ -62,10 +63,9 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, Reentra
     }
 
     /// @notice Constructor
-    /// @param _acl ACL contract address
     /// @param _creditManager Credit manager to connect to
     /// @dev Copies allowed adaprters from the currently connected configurator
-    constructor(address _acl, address _creditManager) ControlledTrait(_acl) {
+    constructor(address _creditManager) ControlledTrait(IPoolV3(CreditManagerV3(_creditManager).pool()).acl()) {
         creditManager = _creditManager; // I:[CC-1]
         underlying = CreditManagerV3(_creditManager).underlying(); // I:[CC-1]
 

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -65,7 +65,10 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, Reentra
     /// @notice Constructor
     /// @param _creditManager Credit manager to connect to
     /// @dev Copies allowed adaprters from the currently connected configurator
-    constructor(address _creditManager) ControlledTrait(IPoolV3(CreditManagerV3(_creditManager).pool()).acl()) {
+    /// @dev Reverts if `_creditManager` is zero address
+    constructor(address _creditManager)
+        ControlledTrait(_creditManager == address(0) ? address(0) : IPoolV3(CreditManagerV3(_creditManager).pool()).acl()) // I:[CC-1]
+    {
         creditManager = _creditManager; // I:[CC-1]
         underlying = CreditManagerV3(_creditManager).underlying(); // I:[CC-1]
 

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -151,7 +151,6 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     }
 
     /// @notice Constructor
-    /// @param _acl ACL contract address
     /// @param _creditManager Credit manager to connect this facade to
     /// @param _botList Bot list address
     /// @param _weth WETH token address
@@ -159,14 +158,9 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     /// @param _expirable Whether this facade should be expirable. If `true`, the expiration date remains unset,
     ///        and facade never expires, unless the date is set via `setExpirationDate` in the configurator.
     /// @dev Reverts if `_creditManager` is not added to the `_botList`
-    constructor(
-        address _acl,
-        address _creditManager,
-        address _botList,
-        address _weth,
-        address _degenNFT,
-        bool _expirable
-    ) ACLTrait(_acl) {
+    constructor(address _creditManager, address _botList, address _weth, address _degenNFT, bool _expirable)
+        ACLTrait(IPoolV3(ICreditManagerV3(_creditManager).pool()).acl())
+    {
         creditManager = _creditManager; // U:[FA-1]
         botList = _botList; // U:[FA-1]
         weth = _weth; // U:[FA-1]

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -153,7 +153,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     /// @notice Constructor
     /// @param _creditManager Credit manager to connect this facade to
     /// @param _botList Bot list address
-    /// @param _weth WETH token address
+    /// @param _weth WETH token address or `address(0)`
     /// @param _degenNFT Degen NFT address or `address(0)`
     /// @param _expirable Whether this facade should be expirable. If `true`, the expiration date remains unset,
     ///        and facade never expires, unless the date is set via `setExpirationDate` in the configurator.

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -157,7 +157,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @dev Sets `msg.sender` as credit configurator, which MUST then pass the role to `CreditConfiguratorV3` contract
     ///      once it's deployed via `setCreditConfigurator`. The latter performs crucial sanity checks, and configuring
     ///      the credit manager without them might have dramatic consequences.
-    /// @dev Reverts if `_accountFactory` is zero address
+    /// @dev Reverts if any of `_pool`, `_accountFactory` or `_priceOracle` is zero address
     /// @dev Reverts if `_maxEnabledTokens` is zero
     constructor(
         address _pool,
@@ -167,7 +167,9 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         uint16 _feeInterest,
         string memory _name
     )
+        nonZeroAddress(_pool) // U:[CM-1]
         nonZeroAddress(_accountFactory) // U:[CM-1]
+        nonZeroAddress(_priceOracle) // U:[CM-1]
     {
         if (_maxEnabledTokens == 0) revert IncorrectParameterException(); // U:[CM-1]
 

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -157,6 +157,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
     /// @dev Sets `msg.sender` as credit configurator, which MUST then pass the role to `CreditConfiguratorV3` contract
     ///      once it's deployed via `setCreditConfigurator`. The latter performs crucial sanity checks, and configuring
     ///      the credit manager without them might have dramatic consequences.
+    /// @dev Reverts if `_accountFactory` is zero address
     /// @dev Reverts if `_maxEnabledTokens` is zero
     constructor(
         address _pool,
@@ -165,7 +166,9 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         uint8 _maxEnabledTokens,
         uint16 _feeInterest,
         string memory _name
-    ) {
+    )
+        nonZeroAddress(_accountFactory) // U:[CM-1]
+    {
         if (_maxEnabledTokens == 0) revert IncorrectParameterException(); // U:[CM-1]
 
         pool = _pool; // U:[CM-1]

--- a/contracts/interfaces/IExceptions.sol
+++ b/contracts/interfaces/IExceptions.sol
@@ -75,20 +75,11 @@ error BorrowingMoreThanU2ForbiddenException();
 /// @notice Thrown when a credit manager attempts to borrow more beyond its own or total debt limit
 error CreditManagerCantBorrowException();
 
-/// @notice Thrown when attempting to set an incompatible quota keeper contract
-error IncompatibleQuotaKeeperException();
-
 /// @notice Thrown when attempting to set an incompatible gauge contract
 error IncompatibleGaugeException();
 
 /// @notice Thrown when the quota is outside of min/max bounds
 error QuotaIsOutOfBoundsException();
-
-/// @notice Thrown when attempting to use an uninitialized quota keeper
-error QuotaKeeperNotInitializedException();
-
-/// @notice Thrown when attempting to initialize an already initialized quota keeper
-error QuotaKeeperAlreadyInitializedException();
 
 // -------------- //
 // CREDIT MANAGER //

--- a/contracts/interfaces/IPoolV3.sol
+++ b/contracts/interfaces/IPoolV3.sol
@@ -30,9 +30,6 @@ interface IPoolV3 is IControlledTrait, IContractsRegisterTrait, IVersion, IERC46
     /// @notice Emitted when new interest rate model contract is set
     event SetInterestRateModel(address indexed newInterestRateModel);
 
-    /// @notice Emitted when the quota keeper contract is initialized
-    event SetPoolQuotaKeeper(address indexed quotaKeeper);
-
     /// @notice Emitted when new total debt limit is set
     event SetTotalDebtLimit(uint256 limit);
 
@@ -128,8 +125,6 @@ interface IPoolV3 is IControlledTrait, IContractsRegisterTrait, IVersion, IERC46
     // ------------- //
 
     function setInterestRateModel(address newInterestRateModel) external;
-
-    function setPoolQuotaKeeper(address quotaKeeper) external;
 
     function setTotalDebtLimit(uint256 newLimit) external;
 

--- a/contracts/pool/GaugeV3.sol
+++ b/contracts/pool/GaugeV3.sol
@@ -54,14 +54,12 @@ contract GaugeV3 is IGaugeV3, ControlledTrait, SanityCheckTrait {
     }
 
     /// @notice Constructor
-    /// @param  acl_ ACL contract address
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  gearStaking_ Address of the GEAR staking contract
     /// @dev    Reverts if any of `quotaKeeper_` or `gearStaking_` is zero address
     /// @custom:tests U:[GA-1]
-    constructor(address acl_, address quotaKeeper_, address gearStaking_)
-        ControlledTrait(acl_)
-        nonZeroAddress(quotaKeeper_)
+    constructor(address quotaKeeper_, address gearStaking_)
+        ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl())
         nonZeroAddress(gearStaking_)
     {
         quotaKeeper = quotaKeeper_;

--- a/contracts/pool/GaugeV3.sol
+++ b/contracts/pool/GaugeV3.sol
@@ -56,8 +56,12 @@ contract GaugeV3 is IGaugeV3, ControlledTrait, SanityCheckTrait {
     /// @notice Constructor
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  gearStaking_ Address of the GEAR staking contract
+    /// @dev    Reverts if any of `quotaKeeper_` or `gearStaking_` is zero address
     /// @custom:tests U:[GA-1]
-    constructor(address quotaKeeper_, address gearStaking_) ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl()) {
+    constructor(address quotaKeeper_, address gearStaking_)
+        ControlledTrait(quotaKeeper_ == address(0) ? address(0) : IPoolQuotaKeeperV3(quotaKeeper_).acl())
+        nonZeroAddress(gearStaking_)
+    {
         quotaKeeper = quotaKeeper_;
         voter = gearStaking_;
         epochLastUpdate = _getCurrentEpoch();

--- a/contracts/pool/GaugeV3.sol
+++ b/contracts/pool/GaugeV3.sol
@@ -56,12 +56,8 @@ contract GaugeV3 is IGaugeV3, ControlledTrait, SanityCheckTrait {
     /// @notice Constructor
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  gearStaking_ Address of the GEAR staking contract
-    /// @dev    Reverts if any of `quotaKeeper_` or `gearStaking_` is zero address
     /// @custom:tests U:[GA-1]
-    constructor(address quotaKeeper_, address gearStaking_)
-        ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl())
-        nonZeroAddress(gearStaking_)
-    {
+    constructor(address quotaKeeper_, address gearStaking_) ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl()) {
         quotaKeeper = quotaKeeper_;
         voter = gearStaking_;
         epochLastUpdate = _getCurrentEpoch();

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -74,14 +74,17 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ControlledTrait, ContractsRegi
     }
 
     /// @notice Constructor
-    /// @param pool_ Pool address
+    /// @param  acl_ ACL contract address
+    /// @param  contractsRegister_ Contracts register address
+    /// @param  underlying_ Underlying token address
+    /// @param  pool_ Pool address
     /// @custom:tests U:[QK-1]
-    constructor(address pool_)
-        ControlledTrait(IPoolV3(pool_).acl())
-        ContractsRegisterTrait(IPoolV3(pool_).contractsRegister())
+    constructor(address acl_, address contractsRegister_, address underlying_, address pool_)
+        ControlledTrait(acl_)
+        ContractsRegisterTrait(contractsRegister_)
     {
         pool = pool_;
-        underlying = IPoolV3(pool_).asset();
+        underlying = underlying_;
     }
 
     /// @notice Whether `creditManager` is added

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -78,6 +78,7 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ControlledTrait, ContractsRegi
     /// @param  contractsRegister_ Contracts register address
     /// @param  underlying_ Underlying token address
     /// @param  pool_ Pool address
+    /// @dev    Quota keeper is deployed via `CREATE2` inside pool's constructor so inputs validity is ensured there
     /// @custom:tests U:[QK-1]
     constructor(address acl_, address contractsRegister_, address underlying_, address pool_)
         ControlledTrait(acl_)

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -74,13 +74,11 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ControlledTrait, ContractsRegi
     }
 
     /// @notice Constructor
-    /// @param acl_ ACL contract address
-    /// @param contractsRegister_ Contracts register address
     /// @param pool_ Pool address
     /// @custom:tests U:[QK-1]
-    constructor(address acl_, address contractsRegister_, address pool_)
-        ControlledTrait(acl_)
-        ContractsRegisterTrait(contractsRegister_)
+    constructor(address pool_)
+        ControlledTrait(IPoolV3(pool_).acl())
+        ContractsRegisterTrait(IPoolV3(pool_).contractsRegister())
     {
         pool = pool_;
         underlying = IPoolV3(pool_).asset();

--- a/contracts/pool/PoolV3.sol
+++ b/contracts/pool/PoolV3.sol
@@ -143,7 +143,7 @@ contract PoolV3 is
         bytes32 salt_
     )
         ControlledTrait(acl_) // U:[LP-1A]
-        ContractsRegisterTrait(contractsRegister_)
+        ContractsRegisterTrait(contractsRegister_) // U:[LP-1A]
         ERC4626(IERC20(underlying_)) // U:[LP-1B]
         ERC20(name_, symbol_) // U:[LP-1B]
         ERC20Permit(name_) // U:[LP-1B]

--- a/contracts/pool/PoolV3_USDT.sol
+++ b/contracts/pool/PoolV3_USDT.sol
@@ -15,15 +15,16 @@ contract PoolV3_USDT is PoolV3, USDT_Transfer {
     constructor(
         address acl_,
         address contractsRegister_,
-        address underlyingToken_,
+        address underlying_,
         address treasury_,
         address interestRateModel_,
         uint256 totalDebtLimit_,
         string memory name_,
-        string memory symbol_
+        string memory symbol_,
+        bytes32 salt_
     )
-        PoolV3(acl_, contractsRegister_, underlyingToken_, treasury_, interestRateModel_, totalDebtLimit_, name_, symbol_)
-        USDT_Transfer(underlyingToken_)
+        PoolV3(acl_, contractsRegister_, underlying_, treasury_, interestRateModel_, totalDebtLimit_, name_, symbol_, salt_)
+        USDT_Transfer(underlying_)
     {}
 
     function _amountWithFee(uint256 amount) internal view override returns (uint256) {

--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -32,14 +32,10 @@ contract TumblerV3 is ITumblerV3, ControlledTrait, SanityCheckTrait {
     mapping(address => uint16) internal _rates;
 
     /// @notice Constructor
-    /// @param  acl_ ACL contract address
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  epochLength_ Epoch length in seconds
     /// @custom:tests U:[TU-1]
-    constructor(address acl_, address quotaKeeper_, uint256 epochLength_)
-        ControlledTrait(acl_)
-        nonZeroAddress(quotaKeeper_)
-    {
+    constructor(address quotaKeeper_, uint256 epochLength_) ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl()) {
         quotaKeeper = quotaKeeper_;
         epochLength = epochLength_;
     }

--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -34,8 +34,11 @@ contract TumblerV3 is ITumblerV3, ControlledTrait, SanityCheckTrait {
     /// @notice Constructor
     /// @param  quotaKeeper_ Address of the quota keeper to provide rates for
     /// @param  epochLength_ Epoch length in seconds
+    /// @dev    Reverts if `quotaKeeper_` is zero address
     /// @custom:tests U:[TU-1]
-    constructor(address quotaKeeper_, uint256 epochLength_) ControlledTrait(IPoolQuotaKeeperV3(quotaKeeper_).acl()) {
+    constructor(address quotaKeeper_, uint256 epochLength_)
+        ControlledTrait(quotaKeeper_ == address(0) ? address(0) : IPoolQuotaKeeperV3(quotaKeeper_).acl())
+    {
         quotaKeeper = quotaKeeper_;
         epochLength = epochLength_;
     }

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -576,7 +576,7 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
         vm.roll(block.number + 1);
     }
 
-    function expectSafeAllowance(address creditAccount, address target) internal {
+    function expectSafeAllowance(address creditAccount, address target) internal view {
         uint256 len = creditManager.collateralTokensCount();
         for (uint256 i = 0; i < len; i++) {
             (address token,) = creditManager.collateralTokenByMask(1 << i);

--- a/contracts/test/helpers/IntegrationTestHelper.sol
+++ b/contracts/test/helpers/IntegrationTestHelper.sol
@@ -393,7 +393,7 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
                 cmParams.name
             );
 
-            creditConfigurator = new CreditConfiguratorV3(address(acl), address(creditManager));
+            creditConfigurator = new CreditConfiguratorV3(address(creditManager));
             creditManager.setCreditConfigurator(address(creditConfigurator));
 
             vm.startPrank(CONFIGURATOR);
@@ -405,7 +405,6 @@ contract IntegrationTestHelper is TestHelper, BalanceHelper, ConfigManager {
             vm.stopPrank();
 
             creditFacade = new CreditFacadeV3(
-                address(acl),
                 address(creditManager),
                 address(botList),
                 weth,

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -119,6 +119,9 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
 
     /// @dev I:[CC-1]: constructor sets correct values
     function test_I_CC_01_constructor_sets_correct_values() public creditTest {
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditConfiguratorV3(address(0));
+
         assertEq(address(creditConfigurator.creditManager()), address(creditManager), "Incorrect creditManager");
 
         assertEq(address(creditConfigurator.creditFacade()), address(creditFacade), "Incorrect creditFacade");

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -29,7 +29,6 @@ import "../../lib/constants.sol";
 // MOCKS
 import {AdapterMock} from "../../mocks/core/AdapterMock.sol";
 import {TargetContractMock} from "../../mocks/core/TargetContractMock.sol";
-import {CreditFacadeV3Harness} from "../../unit/credit/CreditFacadeV3Harness.sol";
 import {IntegrationTestHelper} from "../../helpers/IntegrationTestHelper.sol";
 import {FlagState, PriceFeedMock} from "../../mocks/oracles/PriceFeedMock.sol";
 import {PhantomTokenMock} from "../../mocks/token/PhantomTokenMock.sol";
@@ -64,7 +63,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         uint16 liquidationDiscount,
         uint16 feeLiquidationExpired,
         uint16 liquidationDiscountExpired
-    ) internal {
+    ) internal view {
         (
             ,
             uint16 feeLiquidation2,
@@ -802,7 +801,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
     {
         if (expirable) {
             CreditFacadeV3 initialCf =
-                new CreditFacadeV3(address(acl), address(creditManager), address(botList), address(0), address(0), true);
+                new CreditFacadeV3(address(creditManager), address(botList), address(0), address(0), true);
 
             vm.prank(CONFIGURATOR);
             creditConfigurator.setCreditFacade(address(initialCf));
@@ -821,9 +820,8 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         vm.prank(CONFIGURATOR);
         creditConfigurator.setMaxDebtPerBlockMultiplier(DEFAULT_LIMIT_PER_BLOCK_MULTIPLIER + 1);
 
-        CreditFacadeV3 cf = new CreditFacadeV3(
-            address(acl), address(creditManager), address(botList), address(0), address(0), expirable
-        );
+        CreditFacadeV3 cf =
+            new CreditFacadeV3(address(creditManager), address(botList), address(0), address(0), expirable);
 
         uint8 maxDebtPerBlockMultiplier = creditFacade.maxDebtPerBlockMultiplier();
 
@@ -860,8 +858,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
     function test_I_CC_22B_setCreditFacade_reverts_if_new_facade_is_adapter() public creditTest {
         vm.startPrank(CONFIGURATOR);
 
-        CreditFacadeV3 cf =
-            new CreditFacadeV3(address(acl), address(creditManager), address(botList), address(0), address(0), false);
+        CreditFacadeV3 cf = new CreditFacadeV3(address(creditManager), address(botList), address(0), address(0), false);
         AdapterMock adapter = new AdapterMock(address(creditManager), address(cf));
         TargetContractMock target = new TargetContractMock();
 
@@ -897,8 +894,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
 
         vm.stopPrank();
 
-        CreditFacadeV3 cf =
-            new CreditFacadeV3(address(acl), address(creditManager), address(botList), address(0), address(0), false);
+        CreditFacadeV3 cf = new CreditFacadeV3(address(creditManager), address(botList), address(0), address(0), false);
 
         vm.prank(CONFIGURATOR);
         creditConfigurator.setCreditFacade(address(cf));
@@ -915,9 +911,8 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         BotListV3 otherBotList = new BotListV3(address(this));
         otherBotList.addCreditManager(address(creditManager));
 
-        CreditFacadeV3 newCreditFacade = new CreditFacadeV3(
-            address(acl), address(creditManager), address(otherBotList), address(0), address(0), false
-        );
+        CreditFacadeV3 newCreditFacade =
+            new CreditFacadeV3(address(creditManager), address(otherBotList), address(0), address(0), false);
 
         vm.expectRevert(IncorrectBotListException.selector);
         vm.prank(CONFIGURATOR);
@@ -934,12 +929,12 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         vm.prank(CONFIGURATOR);
         creditConfigurator.allowAdapter(address(adapter1));
 
-        CreditConfiguratorV3 cc1 = new CreditConfiguratorV3(address(acl), address(creditManager));
+        CreditConfiguratorV3 cc1 = new CreditConfiguratorV3(address(creditManager));
 
         vm.prank(CONFIGURATOR);
         creditConfigurator.allowAdapter(address(adapter2));
 
-        CreditConfiguratorV3 cc2 = new CreditConfiguratorV3(address(acl), address(creditManager));
+        CreditConfiguratorV3 cc2 = new CreditConfiguratorV3(address(creditManager));
 
         vm.expectRevert(IncorrectAdaptersSetException.selector);
         vm.prank(CONFIGURATOR);
@@ -1089,7 +1084,7 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper {
         vm.prank(CONFIGURATOR);
         creditConfigurator.allowAdapter(address(adapterMock));
 
-        CreditConfiguratorV3 newConfigurator = new CreditConfiguratorV3(address(acl), address(creditManager));
+        CreditConfiguratorV3 newConfigurator = new CreditConfiguratorV3(address(creditManager));
 
         address[] memory newAllowedAdapters = newConfigurator.allowedAdapters();
 

--- a/contracts/test/integration/governance/GaugeMigration.int.t.sol
+++ b/contracts/test/integration/governance/GaugeMigration.int.t.sol
@@ -52,7 +52,9 @@ contract GaugeMigrationIntegrationTest is Test {
         pool = new PoolMock(address(addressProvider), address(addressProvider), address(underlying));
 
         // deploy quota keeper and connect it to the pool
-        quotaKeeper = new PoolQuotaKeeperV3(address(pool));
+        quotaKeeper = new PoolQuotaKeeperV3(
+            address(addressProvider), address(addressProvider), address(underlying), address(pool)
+        );
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
         // deploy gauge and connect it to the quota keeper and staking

--- a/contracts/test/integration/governance/GaugeMigration.int.t.sol
+++ b/contracts/test/integration/governance/GaugeMigration.int.t.sol
@@ -49,14 +49,14 @@ contract GaugeMigrationIntegrationTest is Test {
         // deploy address provider, staking and pool
         addressProvider = new AddressProviderV3ACLMock();
         staking = new GearStakingV3(configurator, address(gear), block.timestamp);
-        pool = new PoolMock(address(addressProvider), address(underlying));
+        pool = new PoolMock(address(addressProvider), address(addressProvider), address(underlying));
 
         // deploy quota keeper and connect it to the pool
-        quotaKeeper = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(pool));
+        quotaKeeper = new PoolQuotaKeeperV3(address(pool));
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
         // deploy gauge and connect it to the quota keeper and staking
-        gauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(staking));
+        gauge = new GaugeV3(address(quotaKeeper), address(staking));
         staking.setVotingContractStatus(address(gauge), VotingContractStatus.ALLOWED);
         quotaKeeper.setGauge(address(gauge));
 
@@ -102,7 +102,7 @@ contract GaugeMigrationIntegrationTest is Test {
     function test_I_GAM_01_gauge_migration_works_as_expected() public {
         // prepare a new gauge and disable an old one
         vm.startPrank(configurator);
-        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(staking));
+        GaugeV3 newGauge = new GaugeV3(address(quotaKeeper), address(staking));
 
         staking.setVotingContractStatus(address(newGauge), VotingContractStatus.ALLOWED);
         staking.setVotingContractStatus(address(gauge), VotingContractStatus.UNVOTE_ONLY);
@@ -167,7 +167,7 @@ contract GaugeMigrationIntegrationTest is Test {
         // prepare new staking and gauge contracts
         vm.startPrank(configurator);
         GearStakingV3 newStaking = new GearStakingV3(configurator, address(gear), block.timestamp);
-        GaugeV3 newGauge = new GaugeV3(address(addressProvider), address(quotaKeeper), address(newStaking));
+        GaugeV3 newGauge = new GaugeV3(address(quotaKeeper), address(newStaking));
 
         newStaking.setMigrator(address(staking));
         staking.setSuccessor(address(newStaking));

--- a/contracts/test/integration/governance/QuotaRates.int.t.sol
+++ b/contracts/test/integration/governance/QuotaRates.int.t.sol
@@ -31,7 +31,9 @@ contract QuotaRatesIntegrationTest is Test {
         token2 = new ERC20Mock("Test Token 2", "TEST2", 18);
         pool = new PoolMock(address(addressProvider), address(addressProvider), address(underlying));
 
-        quotaKeeper = new PoolQuotaKeeperV3(address(pool));
+        quotaKeeper = new PoolQuotaKeeperV3(
+            address(addressProvider), address(addressProvider), address(underlying), address(pool)
+        );
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
         tumbler = new TumblerV3(address(quotaKeeper), 1 days);

--- a/contracts/test/integration/governance/QuotaRates.int.t.sol
+++ b/contracts/test/integration/governance/QuotaRates.int.t.sol
@@ -29,12 +29,12 @@ contract QuotaRatesIntegrationTest is Test {
         underlying = new ERC20Mock("Underlying", "UND", 18);
         token1 = new ERC20Mock("Test Token 1", "TEST1", 18);
         token2 = new ERC20Mock("Test Token 2", "TEST2", 18);
-        pool = new PoolMock(address(addressProvider), address(underlying));
+        pool = new PoolMock(address(addressProvider), address(addressProvider), address(underlying));
 
-        quotaKeeper = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(pool));
+        quotaKeeper = new PoolQuotaKeeperV3(address(pool));
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
-        tumbler = new TumblerV3(address(addressProvider), address(quotaKeeper), 1 days);
+        tumbler = new TumblerV3(address(quotaKeeper), 1 days);
         quotaKeeper.setGauge(address(tumbler));
     }
 

--- a/contracts/test/lib/helper.sol
+++ b/contracts/test/lib/helper.sol
@@ -134,17 +134,20 @@ contract TestHelper is Test {
         array[3] = v4;
     }
 
-    function assertEq(uint16[] memory a1, uint16[] memory a2, string memory reason) internal {
+    function assertEq(uint16[] memory a1, uint16[] memory a2, string memory reason) internal pure {
         assertEq(a1.length, a2.length, string.concat(reason, "Arrays has different length"));
 
         assertEq(_copyU16toU256(a1), _copyU16toU256(a2), reason);
     }
 
-    function assertEq(CollateralDebtData memory cdd1, CollateralDebtData memory cdd2) internal {
+    function assertEq(CollateralDebtData memory cdd1, CollateralDebtData memory cdd2) internal pure {
         assertEq(cdd1, cdd2, "");
     }
 
-    function assertEq(CollateralDebtData memory cdd1, CollateralDebtData memory cdd2, string memory reason) internal {
+    function assertEq(CollateralDebtData memory cdd1, CollateralDebtData memory cdd2, string memory reason)
+        internal
+        pure
+    {
         assertEq(cdd1.debt, cdd2.debt, string.concat(reason, "\nIncorrect debt"));
         assertEq(
             cdd1.cumulativeIndexNow, cdd2.cumulativeIndexNow, string.concat(reason, "\nIncorrect cumulativeIndexNow")

--- a/contracts/test/mocks/pool/PoolMock.sol
+++ b/contracts/test/mocks/pool/PoolMock.sol
@@ -19,8 +19,8 @@ import "../../../interfaces/IExceptions.sol";
 contract PoolMock {
     using SafeERC20 for IERC20;
 
-    // Address repository
-    address public addressProvider;
+    address public acl;
+    address public contractsRegister;
 
     // Total borrowed amount: https://dev.gearbox.fi/developers/pool/economy/total-borrowed
     uint256 public totalBorrowed;
@@ -78,8 +78,9 @@ contract PoolMock {
         _;
     }
 
-    constructor(address _addressProvider, address _underlyingToken) {
-        addressProvider = _addressProvider;
+    constructor(address _acl, address _contractsRegister, address _underlyingToken) {
+        acl = _acl;
+        contractsRegister = _contractsRegister;
         underlyingToken = _underlyingToken;
         asset = _underlyingToken;
         borrowAPY_RAY = RAY / 10;

--- a/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
+++ b/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
@@ -3,16 +3,16 @@
 // (c) Gearbox Foundation, 2023.
 pragma solidity ^0.8.23;
 
+import {IPoolV3} from "../../../interfaces/IPoolV3.sol";
 import {IPoolQuotaKeeperV3, TokenQuotaParams, AccountQuota} from "../../../interfaces/IPoolQuotaKeeperV3.sol";
 
 contract PoolQuotaKeeperMock {
     uint256 public constant version = 3_10;
 
-    /// @dev Address provider
     address public immutable underlying;
-
-    /// @dev Address of the protocol treasury
     address public immutable pool;
+    address public immutable acl;
+    address public immutable contractsRegister;
 
     /// @dev Address of the gauge that determines quota rates
     address public gauge;
@@ -40,6 +40,8 @@ contract PoolQuotaKeeperMock {
     mapping(address => uint128) internal _outstandingInterest;
 
     constructor(address _pool, address _underlying) {
+        acl = IPoolV3(_pool).acl();
+        contractsRegister = IPoolV3(_pool).contractsRegister();
         pool = _pool;
         underlying = _underlying;
     }

--- a/contracts/test/suites/PoolFactory.sol
+++ b/contracts/test/suites/PoolFactory.sol
@@ -48,19 +48,16 @@ contract PoolFactory is Test {
         pool = new PoolV3({
             acl_: acl,
             contractsRegister_: contractsRegister,
-            underlyingToken_: underlying,
+            underlying_: underlying,
             treasury_: IAddressProviderV3(addressProvider).getAddressOrRevert(AP_TREASURY, NO_VERSION_CONTROL),
             interestRateModel_: address(irm),
             totalDebtLimit_: type(uint256).max,
             name_: config.name(),
-            symbol_: config.symbol()
+            symbol_: config.symbol(),
+            salt_: bytes32(0)
         });
 
-        poolQuotaKeeper = new PoolQuotaKeeperV3(payable(address(pool)));
-
-        vm.prank(CONFIGURATOR);
-        pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
-
+        poolQuotaKeeper = PoolQuotaKeeperV3(pool.poolQuotaKeeper());
         vm.label(address(poolQuotaKeeper), string.concat("PoolQuotaKeeperV3-", config.symbol()));
 
         address gearStaking = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_GEAR_STAKING, 3_10);

--- a/contracts/test/suites/PoolFactory.sol
+++ b/contracts/test/suites/PoolFactory.sol
@@ -56,7 +56,7 @@ contract PoolFactory is Test {
             symbol_: config.symbol()
         });
 
-        poolQuotaKeeper = new PoolQuotaKeeperV3(acl, contractsRegister, payable(address(pool)));
+        poolQuotaKeeper = new PoolQuotaKeeperV3(payable(address(pool)));
 
         vm.prank(CONFIGURATOR);
         pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
@@ -64,7 +64,7 @@ contract PoolFactory is Test {
         vm.label(address(poolQuotaKeeper), string.concat("PoolQuotaKeeperV3-", config.symbol()));
 
         address gearStaking = IAddressProviderV3(addressProvider).getAddressOrRevert(AP_GEAR_STAKING, 3_10);
-        gauge = new GaugeV3(acl, address(poolQuotaKeeper), gearStaking);
+        gauge = new GaugeV3(address(poolQuotaKeeper), gearStaking);
         vm.prank(CONFIGURATOR);
         gauge.setFrozenEpoch(false);
 

--- a/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
+++ b/contracts/test/unit/core/AccountFactoryV3.unit.t.sol
@@ -10,8 +10,7 @@ import {
     CallerNotCreditManagerException,
     CreditAccountIsInUseException,
     CreditManagerNotAddedException,
-    MasterCreditAccountAlreadyDeployedException,
-    RegisteredCreditManagerOnlyException
+    MasterCreditAccountAlreadyDeployedException
 } from "../../../interfaces/IExceptions.sol";
 
 import {TestHelper} from "../../lib/helper.sol";

--- a/contracts/test/unit/core/GearStakingV3.unit.t.sol
+++ b/contracts/test/unit/core/GearStakingV3.unit.t.sol
@@ -57,6 +57,9 @@ contract GearStakingV3UnitTest is Test {
 
     /// @dev U:[GS-1]: constructor sets correct values
     function test_U_GS_01_constructor_sets_correct_values() public {
+        vm.expectRevert(ZeroAddressException.selector);
+        new GearStakingV3(CONFIGURATOR, address(0), block.timestamp);
+
         assertEq(address(gearStaking.gear()), gearToken, "Gear token incorrect");
         assertEq(gearStaking.getCurrentEpoch(), 0, "First epoch timestamp incorrect");
 

--- a/contracts/test/unit/core/PriceOracleV3.unit.t.sol
+++ b/contracts/test/unit/core/PriceOracleV3.unit.t.sol
@@ -256,7 +256,7 @@ contract PriceOracleV3UnitTest is Test {
     // ------------------ //
 
     /// @notice U:[PO-6]: `_getTokenReserveKey` works as expected
-    function test_U_PO_06_getTokenReserveKey_works_as_expected(address token) public {
+    function test_U_PO_06_getTokenReserveKey_works_as_expected(address token) public view {
         address expectedKey = address(uint160(uint256(keccak256(abi.encodePacked("RESERVE", token)))));
         assertEq(priceOracle.exposed_getTokenReserveKey(token), expectedKey);
     }

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -190,6 +190,12 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper {
 
         assertEq(creditFacade.degenNFT(), address(degenNFTMock), "Incorrect degen NFT");
 
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditFacadeV3Harness(address(0), address(botListMock), weth, address(degenNFTMock), expirable);
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditFacadeV3Harness(address(creditManagerMock), address(0), weth, address(degenNFTMock), expirable);
+
         botListMock.setCreditManagerAddedReturns(false);
         vm.expectRevert(CreditManagerNotAddedException.selector);
         new CreditFacadeV3Harness(

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -185,9 +185,16 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper {
         assertEq(creditFacade.underlying(), tokenTestSuite.addressOf(Tokens.DAI), "Incorrect underlying");
         assertEq(creditFacade.treasury(), treasury, "Incorrect treasury");
 
-        assertEq(creditFacade.weth(), tokenTestSuite.addressOf(Tokens.WETH), "Incorrect weth token");
+        address weth = tokenTestSuite.addressOf(Tokens.WETH);
+        assertEq(creditFacade.weth(), weth, "Incorrect weth token");
 
         assertEq(creditFacade.degenNFT(), address(degenNFTMock), "Incorrect degen NFT");
+
+        botListMock.setCreditManagerAddedReturns(false);
+        vm.expectRevert(CreditManagerNotAddedException.selector);
+        new CreditFacadeV3Harness(
+            address(creditManagerMock), address(botListMock), weth, address(degenNFTMock), expirable
+        );
     }
 
     /// @dev U:[FA-2]: user functions revert if called on pause

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -139,7 +139,8 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper {
 
         AddressProviderV3ACLMock(address(addressProvider)).addPausableAdmin(CONFIGURATOR);
 
-        PoolMock poolMock = new PoolMock(address(addressProvider), tokenTestSuite.addressOf(Tokens.DAI));
+        PoolMock poolMock =
+            new PoolMock(address(addressProvider), address(addressProvider), tokenTestSuite.addressOf(Tokens.DAI));
         treasury = makeAddr("TREASURY");
         poolMock.setTreasury(treasury);
 
@@ -168,7 +169,6 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper {
 
     function _deploy() internal {
         creditFacade = new CreditFacadeV3Harness(
-            address(addressProvider),
             address(creditManagerMock),
             address(botListMock),
             tokenTestSuite.addressOf(Tokens.WETH),

--- a/contracts/test/unit/credit/CreditFacadeV3Harness.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3Harness.sol
@@ -9,14 +9,9 @@ import {ManageDebtAction, CollateralDebtData} from "../../../interfaces/ICreditM
 import {BalanceWithMask} from "../../../libraries/BalancesLogic.sol";
 
 contract CreditFacadeV3Harness is CreditFacadeV3 {
-    constructor(
-        address acl,
-        address _creditManager,
-        address _botList,
-        address _weth,
-        address _degenNFT,
-        bool _expirable
-    ) CreditFacadeV3(acl, _creditManager, _botList, _weth, _degenNFT, _expirable) {}
+    constructor(address _creditManager, address _botList, address _weth, address _degenNFT, bool _expirable)
+        CreditFacadeV3(_creditManager, _botList, _weth, _degenNFT, _expirable)
+    {}
 
     function setReentrancy(uint8 _status) external {
         _reentrancyStatus = _status;

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -126,7 +126,7 @@ contract CreditManagerV3UnitTest is TestHelper, BalanceHelper, CreditAccountMock
     ///
 
     function _deployCreditManager() internal {
-        poolMock = new PoolMock(address(addressProvider), underlying);
+        poolMock = new PoolMock(address(addressProvider), address(addressProvider), underlying);
 
         poolQuotaKeeperMock = new PoolQuotaKeeperMock(address(poolMock), underlying);
         poolMock.setPoolQuotaKeeper(address(poolQuotaKeeperMock));

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -277,6 +277,17 @@ contract CreditManagerV3UnitTest is TestHelper, BalanceHelper, CreditAccountMock
 
     /// @dev U:[CM-1]: credit manager reverts if were called non-creditFacade
     function test_U_CM_01_constructor_sets_correct_values() public creditManagerTest {
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditManagerV3Harness(
+            address(poolMock),
+            address(0),
+            address(priceOracleMock),
+            DEFAULT_MAX_ENABLED_TOKENS,
+            DEFAULT_FEE_INTEREST,
+            name,
+            isFeeToken
+        );
+
         vm.expectRevert(IncorrectParameterException.selector);
         new CreditManagerV3Harness(
             address(poolMock),

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -8,7 +8,6 @@ import "../../interfaces/IAddressProviderV3.sol";
 import {AddressProviderV3ACLMock} from "../../mocks/core/AddressProviderV3ACLMock.sol";
 import {AccountFactoryMock} from "../../mocks/core/AccountFactoryMock.sol";
 
-import {CreditManagerV3} from "../../../credit/CreditManagerV3.sol";
 import {CreditManagerV3Harness} from "./CreditManagerV3Harness.sol";
 import "../../../libraries/Constants.sol";
 
@@ -279,49 +278,59 @@ contract CreditManagerV3UnitTest is TestHelper, BalanceHelper, CreditAccountMock
     /// @dev U:[CM-1]: credit manager reverts if were called non-creditFacade
     function test_U_CM_01_constructor_sets_correct_values() public creditManagerTest {
         vm.expectRevert(ZeroAddressException.selector);
-        new CreditManagerV3(
+        new CreditManagerV3Harness(
             address(0),
             address(accountFactory),
             address(priceOracleMock),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name
+            name,
+            isFeeToken
         );
 
         vm.expectRevert(ZeroAddressException.selector);
-        new CreditManagerV3(
+        new CreditManagerV3Harness(
             address(poolMock),
             address(0),
             address(priceOracleMock),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name
+            name,
+            isFeeToken
         );
 
         vm.expectRevert(ZeroAddressException.selector);
-        new CreditManagerV3(
+        new CreditManagerV3Harness(
             address(poolMock),
             address(accountFactory),
             address(0),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name
+            name,
+            isFeeToken
         );
 
         vm.expectRevert(IncorrectParameterException.selector);
-        new CreditManagerV3(
-            address(poolMock), address(accountFactory), address(priceOracleMock), 0, DEFAULT_FEE_INTEREST, name
+        new CreditManagerV3Harness(
+            address(poolMock),
+            address(accountFactory),
+            address(priceOracleMock),
+            0,
+            DEFAULT_FEE_INTEREST,
+            name,
+            isFeeToken
         );
 
         PriceOracleMock priceOracleMock2 = new PriceOracleMock();
         vm.expectRevert(PriceFeedDoesNotExistException.selector);
-        new CreditManagerV3(
+        new CreditManagerV3Harness(
             address(poolMock),
             address(accountFactory),
             address(priceOracleMock2),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name
+            name,
+            isFeeToken
         );
 
         assertEq(address(creditManager.pool()), address(poolMock), _testCaseErr("Incorrect pool"));

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -8,6 +8,7 @@ import "../../interfaces/IAddressProviderV3.sol";
 import {AddressProviderV3ACLMock} from "../../mocks/core/AddressProviderV3ACLMock.sol";
 import {AccountFactoryMock} from "../../mocks/core/AccountFactoryMock.sol";
 
+import {CreditManagerV3} from "../../../credit/CreditManagerV3.sol";
 import {CreditManagerV3Harness} from "./CreditManagerV3Harness.sol";
 import "../../../libraries/Constants.sol";
 
@@ -278,37 +279,49 @@ contract CreditManagerV3UnitTest is TestHelper, BalanceHelper, CreditAccountMock
     /// @dev U:[CM-1]: credit manager reverts if were called non-creditFacade
     function test_U_CM_01_constructor_sets_correct_values() public creditManagerTest {
         vm.expectRevert(ZeroAddressException.selector);
-        new CreditManagerV3Harness(
+        new CreditManagerV3(
+            address(0),
+            address(accountFactory),
+            address(priceOracleMock),
+            DEFAULT_MAX_ENABLED_TOKENS,
+            DEFAULT_FEE_INTEREST,
+            name
+        );
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditManagerV3(
             address(poolMock),
             address(0),
             address(priceOracleMock),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name,
-            isFeeToken
+            name
+        );
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new CreditManagerV3(
+            address(poolMock),
+            address(accountFactory),
+            address(0),
+            DEFAULT_MAX_ENABLED_TOKENS,
+            DEFAULT_FEE_INTEREST,
+            name
         );
 
         vm.expectRevert(IncorrectParameterException.selector);
-        new CreditManagerV3Harness(
-            address(poolMock),
-            address(accountFactory),
-            address(priceOracleMock),
-            0,
-            DEFAULT_FEE_INTEREST,
-            name,
-            isFeeToken
+        new CreditManagerV3(
+            address(poolMock), address(accountFactory), address(priceOracleMock), 0, DEFAULT_FEE_INTEREST, name
         );
 
         PriceOracleMock priceOracleMock2 = new PriceOracleMock();
         vm.expectRevert(PriceFeedDoesNotExistException.selector);
-        new CreditManagerV3Harness(
+        new CreditManagerV3(
             address(poolMock),
             address(accountFactory),
             address(priceOracleMock2),
             DEFAULT_MAX_ENABLED_TOKENS,
             DEFAULT_FEE_INTEREST,
-            name,
-            isFeeToken
+            name
         );
 
         assertEq(address(creditManager.pool()), address(poolMock), _testCaseErr("Incorrect pool"));

--- a/contracts/test/unit/libraries/BitMask.unit.t.sol
+++ b/contracts/test/unit/libraries/BitMask.unit.t.sol
@@ -14,7 +14,7 @@ contract BitMaskUnitTest is TestHelper {
     using BitMask for uint256;
 
     /// @notice U:[BM-1]: `calcEnabledBits` works correctly
-    function test_U_BM_01_calcEnabledBits_works_correctly(uint8 bitsToEnable, uint256 randomValue) public {
+    function test_U_BM_01_calcEnabledBits_works_correctly(uint8 bitsToEnable, uint256 randomValue) public pure {
         uint256 bitMask;
 
         for (uint256 i; i < bitsToEnable;) {
@@ -30,7 +30,7 @@ contract BitMaskUnitTest is TestHelper {
     }
 
     /// @notice U:[BM-2]: `enable` & `disable` works correctly
-    function test_U_BM_02_enable_and_disable_works_correctly(uint8 bit) public {
+    function test_U_BM_02_enable_and_disable_works_correctly(uint8 bit) public pure {
         uint256 mask;
         mask = mask.enable(1 << bit);
         assertEq(mask, 1 << bit, "Enable doesn't work");
@@ -40,7 +40,7 @@ contract BitMaskUnitTest is TestHelper {
     }
 
     /// @notice U:[BM-3]: `enableDisable` works correctly
-    function test_U_BM_03_enableDisable_works_correctly(uint8 bit) public {
+    function test_U_BM_03_enableDisable_works_correctly(uint8 bit) public pure {
         uint256 mask;
 
         mask = mask.enableDisable(1 << bit, 0);
@@ -51,7 +51,7 @@ contract BitMaskUnitTest is TestHelper {
     }
 
     /// @notice U:[BM-4]: `lsbMask` works correctly
-    function test_U_BM_04_lsbMask_works_correctly(uint256 mask) public {
+    function test_U_BM_04_lsbMask_works_correctly(uint256 mask) public pure {
         uint256 lsbMask = mask.lsbMask();
         if (lsbMask == 0) {
             assertEq(mask, 0, "Zero LSB for non-zero mask");

--- a/contracts/test/unit/libraries/CreditLogic.unit.t.sol
+++ b/contracts/test/unit/libraries/CreditLogic.unit.t.sol
@@ -114,7 +114,7 @@ contract CreditLogicUnitTest is TestHelper {
         uint128 quotaInterest,
         uint128 quotaFees,
         uint16 feeInterest
-    ) internal {
+    ) internal pure {
         (uint256 newDebt, uint256 newIndex,, uint128 newQuotaInterest, uint128 newQuotaFees) =
             CreditLogic.calcDecrease(amount, debt, indexNow, indexLastUpdate, quotaInterest, quotaFees, feeInterest);
 
@@ -138,7 +138,7 @@ contract CreditLogicUnitTest is TestHelper {
         uint128 quotaInterest,
         uint128 quotaFees,
         uint16 feeInterest
-    ) internal {
+    ) internal pure {
         (uint256 newDebt,, uint256 profit,,) =
             CreditLogic.calcDecrease(amount, debt, indexNow, indexLastUpdate, quotaInterest, quotaFees, feeInterest);
 
@@ -160,7 +160,7 @@ contract CreditLogicUnitTest is TestHelper {
         uint128 quotaInterest,
         uint128 quotaFees,
         uint16 feeInterest
-    ) internal {
+    ) internal pure {
         (uint256 newDebt, uint256 newIndex,,,) =
             CreditLogic.calcDecrease(amount, debt, indexNow, indexLastUpdate, quotaInterest, quotaFees, feeInterest);
 
@@ -184,7 +184,7 @@ contract CreditLogicUnitTest is TestHelper {
         uint128 quotaInterest,
         uint128 quotaFees,
         uint16 feeInterest
-    ) internal {
+    ) internal pure {
         (uint256 newDebt,,, uint128 newQuotaInterest, uint128 newQuotaFees) =
             CreditLogic.calcDecrease(amount, debt, indexNow, indexLastUpdate, quotaInterest, quotaFees, feeInterest);
 
@@ -217,7 +217,7 @@ contract CreditLogicUnitTest is TestHelper {
     }
 
     /// @notice U:[CL-4]: `calcLiquidationPayments` gives expected outputs
-    function test_U_CL_04_calcLiquidationPayments_case_test() public {
+    function test_U_CL_04_calcLiquidationPayments_case_test() public view {
         /// FEE INTEREST: 50%
         /// NORMAL LIQUIDATION PREMIUM: 4%
         /// NORMAL LIQUIDATION FEE: 1.5%
@@ -390,7 +390,7 @@ contract CreditLogicUnitTest is TestHelper {
     }
 
     /// @notice U:[CL-5]: `getLiquidationThreshold` gives expected outputs
-    function test_U_CL_05_getLiquidationThreshold_case_test() public {
+    function test_U_CL_05_getLiquidationThreshold_case_test() public view {
         LiquidationThresholdTestCase[6] memory cases = [
             LiquidationThresholdTestCase({
                 name: "LIQUIDATION THRESHOLD RAMP IN THE FUTURE",

--- a/contracts/test/unit/pool/GaugeV3.unit.t.sol
+++ b/contracts/test/unit/pool/GaugeV3.unit.t.sol
@@ -72,9 +72,6 @@ contract GauageV3UnitTest is TestHelper {
         assertEq(gauge.voter(), address(gearStakingMock), "Incorrect voter");
         assertEq(gauge.epochLastUpdate(), 900, "Incorrect epoch");
         assertTrue(gauge.epochFrozen(), "Epoch not frozen");
-
-        vm.expectRevert(ZeroAddressException.selector);
-        new GaugeV3Harness(address(poolQuotaKeeperMock), address(0));
     }
 
     /// @dev U:[GA-2]: voterOnly functions reverts if called by non-voter

--- a/contracts/test/unit/pool/GaugeV3.unit.t.sol
+++ b/contracts/test/unit/pool/GaugeV3.unit.t.sol
@@ -72,6 +72,12 @@ contract GauageV3UnitTest is TestHelper {
         assertEq(gauge.voter(), address(gearStakingMock), "Incorrect voter");
         assertEq(gauge.epochLastUpdate(), 900, "Incorrect epoch");
         assertTrue(gauge.epochFrozen(), "Epoch not frozen");
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new GaugeV3Harness(address(0), address(gearStakingMock));
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new GaugeV3Harness(address(poolQuotaKeeperMock), address(0));
     }
 
     /// @dev U:[GA-2]: voterOnly functions reverts if called by non-voter

--- a/contracts/test/unit/pool/GaugeV3Harness.sol
+++ b/contracts/test/unit/pool/GaugeV3Harness.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.23;
 import {GaugeV3, QuotaRateParams, UserTokenVotes} from "../../../pool/GaugeV3.sol";
 
 contract GaugeV3Harness is GaugeV3 {
-    constructor(address acl, address _pool, address _gearStaking) GaugeV3(acl, _pool, _gearStaking) {}
+    constructor(address _pool, address _gearStaking) GaugeV3(_pool, _gearStaking) {}
 
     function setQuotaRateParams(
         address token,

--- a/contracts/test/unit/pool/LinearInterestRateModelV3.unit.t.sol
+++ b/contracts/test/unit/pool/LinearInterestRateModelV3.unit.t.sol
@@ -31,7 +31,7 @@ contract LinearInterestRateModelV3UnitTest is TestHelper {
     //
 
     /// @notice U:[LIM-1]: start parameters are correct
-    function test_U_LIM_01_start_parameters_correct() public {
+    function test_U_LIM_01_start_parameters_correct() public view {
         (uint16 U_1, uint16 U_2, uint16 R_base, uint16 R_slope1, uint16 R_slope2, uint16 R_slope3) =
             irm.getModelParameters();
 

--- a/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
@@ -64,7 +64,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
 
         poolMock = new PoolMock(address(addressProvider), address(addressProvider), underlying);
 
-        pqk = new PoolQuotaKeeperV3(address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), underlying, address(poolMock));
 
         poolMock.setPoolQuotaKeeper(address(pqk));
 
@@ -276,7 +276,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
 
     /// @notice U:[QK-7]: setGauge works as expected
     function test_U_QK_07_setGauge_works_as_expected() public {
-        pqk = new PoolQuotaKeeperV3(address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), underlying, address(poolMock));
 
         assertEq(pqk.gauge(), address(0), "SETUP: incorrect address at start");
 
@@ -301,7 +301,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
 
     /// @notice U:[QK-8]: addCreditManager works as expected
     function test_U_QK_08_addCreditManager_works_as_expected() public {
-        pqk = new PoolQuotaKeeperV3(address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), underlying, address(poolMock));
 
         address[] memory managers = pqk.creditManagers();
         assertEq(managers.length, 0, "SETUP: at least one creditmanager is unexpectedly connected");

--- a/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
@@ -89,7 +89,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
     //
 
     /// @notice U:[QK-1]: constructor sets parameters correctly
-    function test_U_QK_01_constructor_sets_parameters_correctly() public {
+    function test_U_QK_01_constructor_sets_parameters_correctly() public view {
         assertEq(address(poolMock), pqk.pool(), "Incorrect poolMock address");
         assertEq(underlying, pqk.underlying(), "Incorrect poolMock address");
     }

--- a/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolQuotaKeeperV3.unit.t.sol
@@ -62,9 +62,9 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
         addressProvider = new AddressProviderV3ACLMock();
         addressProvider.setAddress(AP_WETH_TOKEN, tokenTestSuite.addressOf(Tokens.WETH), false);
 
-        poolMock = new PoolMock(address(addressProvider), underlying);
+        poolMock = new PoolMock(address(addressProvider), address(addressProvider), underlying);
 
-        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(poolMock));
 
         poolMock.setPoolQuotaKeeper(address(pqk));
 
@@ -276,7 +276,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
 
     /// @notice U:[QK-7]: setGauge works as expected
     function test_U_QK_07_setGauge_works_as_expected() public {
-        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(poolMock));
 
         assertEq(pqk.gauge(), address(0), "SETUP: incorrect address at start");
 
@@ -301,7 +301,7 @@ contract PoolQuotaKeeperV3UnitTest is TestHelper, BalanceHelper {
 
     /// @notice U:[QK-8]: addCreditManager works as expected
     function test_U_QK_08_addCreditManager_works_as_expected() public {
-        pqk = new PoolQuotaKeeperV3(address(addressProvider), address(addressProvider), address(poolMock));
+        pqk = new PoolQuotaKeeperV3(address(poolMock));
 
         address[] memory managers = pqk.creditManagers();
         assertEq(managers.length, 0, "SETUP: at least one creditmanager is unexpectedly connected");

--- a/contracts/test/unit/pool/PoolV3.unit.t.sol
+++ b/contracts/test/unit/pool/PoolV3.unit.t.sol
@@ -114,6 +114,32 @@ contract PoolV3UnitTest is TestHelper {
     function test_U_LP_01A_constructor_reverts_on_zero_addresses() public {
         vm.expectRevert(ZeroAddressException.selector);
         new PoolV3Harness({
+            acl: address(0),
+            contractsRegister: address(addressProvider),
+            underlying_: address(underlying),
+            treasury_: treasury,
+            interestRateModel_: interestRateModel,
+            totalDebtLimit_: type(uint256).max,
+            name_: "",
+            symbol_: "",
+            salt_: bytes32(0)
+        });
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new PoolV3Harness({
+            acl: address(addressProvider),
+            contractsRegister: address(0),
+            underlying_: address(underlying),
+            treasury_: treasury,
+            interestRateModel_: interestRateModel,
+            totalDebtLimit_: type(uint256).max,
+            name_: "",
+            symbol_: "",
+            salt_: bytes32(0)
+        });
+
+        vm.expectRevert(ZeroAddressException.selector);
+        new PoolV3Harness({
             acl: address(addressProvider),
             contractsRegister: address(addressProvider),
             underlying_: address(0),

--- a/contracts/test/unit/pool/PoolV3Harness.sol
+++ b/contracts/test/unit/pool/PoolV3Harness.sol
@@ -13,14 +13,15 @@ contract PoolV3Harness is PoolV3 {
     constructor(
         address acl,
         address contractsRegister,
-        address underlyingToken_,
+        address underlying_,
         address treasury_,
         address interestRateModel_,
         uint256 totalDebtLimit_,
         string memory name_,
-        string memory symbol_
+        string memory symbol_,
+        bytes32 salt_
     )
-        PoolV3(acl, contractsRegister, underlyingToken_, treasury_, interestRateModel_, totalDebtLimit_, name_, symbol_)
+        PoolV3(acl, contractsRegister, underlying_, treasury_, interestRateModel_, totalDebtLimit_, name_, symbol_, salt_)
     {}
 
     // ------- //
@@ -75,10 +76,6 @@ contract PoolV3Harness is PoolV3 {
     // ------ //
     // QUOTAS //
     // ------ //
-
-    function hackQuotaKeeper(address quotaKeeper) external {
-        _quotaKeeper = quotaKeeper;
-    }
 
     function hackQuotaRevenue(uint256 value) external {
         _quotaRevenue = uint96(value);

--- a/contracts/test/unit/pool/TumblerV3.unit.t.sol
+++ b/contracts/test/unit/pool/TumblerV3.unit.t.sol
@@ -44,9 +44,12 @@ contract TumblerV3UnitTest is Test {
     }
 
     /// @notice U:[TU-1]: Constructor works as expected
-    function test_U_TU_01_constructor_works_as_expected() public view {
+    function test_U_TU_01_constructor_works_as_expected() public {
         assertEq(tumbler.quotaKeeper(), address(poolQuotaKeeper), "Incorrect quotaKeeper");
         assertEq(tumbler.epochLength(), 1 days, "Incorrect epochLength");
+
+        vm.expectRevert(ZeroAddressException.selector);
+        tumbler = new TumblerV3(address(0), 1 days);
     }
 
     /// @notice U:[TU-2]: `addToken` works as expected

--- a/contracts/test/unit/pool/TumblerV3.unit.t.sol
+++ b/contracts/test/unit/pool/TumblerV3.unit.t.sol
@@ -35,21 +35,18 @@ contract TumblerV3UnitTest is Test {
 
     function setUp() public {
         addressProvider = new AddressProviderV3ACLMock();
-        pool = new PoolMock(address(addressProvider), underlying);
+        pool = new PoolMock(address(addressProvider), address(addressProvider), underlying);
         poolQuotaKeeper = new PoolQuotaKeeperMock(address(pool), underlying);
         poolQuotaKeeper.set_lastQuotaRateUpdate(uint40(block.timestamp));
         pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
 
-        tumbler = new TumblerV3(address(addressProvider), address(poolQuotaKeeper), 1 days);
+        tumbler = new TumblerV3(address(poolQuotaKeeper), 1 days);
     }
 
     /// @notice U:[TU-1]: Constructor works as expected
-    function test_U_TU_01_constructor_works_as_expected() public {
+    function test_U_TU_01_constructor_works_as_expected() public view {
         assertEq(tumbler.quotaKeeper(), address(poolQuotaKeeper), "Incorrect quotaKeeper");
         assertEq(tumbler.epochLength(), 1 days, "Incorrect epochLength");
-
-        vm.expectRevert(ZeroAddressException.selector);
-        new TumblerV3(address(addressProvider), address(0), 1 days);
     }
 
     /// @notice U:[TU-2]: `addToken` works as expected

--- a/contracts/test/unit/traits/USDT_Transfer.unit.t.sol
+++ b/contracts/test/unit/traits/USDT_Transfer.unit.t.sol
@@ -3,20 +3,36 @@
 // (c) Gearbox Foundation, 2023.
 pragma solidity ^0.8.23;
 
-import {USDT_Transfer} from "../../../traits/USDT_Transfer.sol";
+import {IncorrectTokenContractException, ZeroAddressException} from "../../../interfaces/IExceptions.sol";
+import {ERC20Mock} from "../../mocks/token/ERC20Mock.sol";
 import {TestHelper} from "../../lib/helper.sol";
+import {USDT_TransferHarness} from "./USDT_TransferHarness.sol";
 
-contract USDT_TransferUnitTest is USDT_Transfer, TestHelper {
+contract USDT_TransferUnitTest is TestHelper {
     uint256 constant SCALE = 10 ** 18;
 
     uint256 public basisPointsRate;
     uint256 public maximumFee;
 
-    constructor() USDT_Transfer(address(this)) {}
+    USDT_TransferHarness trait;
 
-    /// @notice U:[UTT-1]: `amountUSDTWithFee` and `amountUSDTMinusFee` work correctly
+    function setUp() public {
+        trait = new USDT_TransferHarness(address(this));
+    }
+
+    /// @notice U:[UTT-1]: Constructor works as expected
+    function test_U_UTT_01_constructor_works_as_expected() public {
+        vm.expectRevert(ZeroAddressException.selector);
+        new USDT_TransferHarness(address(0));
+
+        ERC20Mock token = new ERC20Mock("Test Token", "TEST", 18);
+        vm.expectRevert(IncorrectTokenContractException.selector);
+        new USDT_TransferHarness(address(token));
+    }
+
+    /// @notice U:[UTT-2]: `amountUSDTWithFee` and `amountUSDTMinusFee` work correctly
     /// forge-config: default.fuzz.runs = 50000
-    function testFuzz_U_UTT_01_amountUSDTWithFee_amountUSDTMinusFee_work_correctly(
+    function testFuzz_U_UTT_02_amountUSDTWithFee_amountUSDTMinusFee_work_correctly(
         uint256 amount,
         uint256 feeRate,
         uint256 maxFee
@@ -26,15 +42,23 @@ contract USDT_TransferUnitTest is USDT_Transfer, TestHelper {
         maximumFee = bound(maxFee, 0, 1000) * SCALE; // up to 1000 USDT
 
         // direction checks
-        assertGe(_amountUSDTWithFee(amount), amount, "amountWithFee less than amount");
-        assertLe(_amountUSDTMinusFee(amount), amount, "amountMinusFee greater than amount");
+        assertGe(trait.amountUSDTWithFee(amount), amount, "amountWithFee less than amount");
+        assertLe(trait.amountUSDTMinusFee(amount), amount, "amountMinusFee greater than amount");
 
         // maximum fee checks
-        assertLe(_amountUSDTWithFee(amount), amount + maximumFee, "amountWithFee fee greater than maximum");
-        assertGe(_amountUSDTMinusFee(amount) + maximumFee, amount, "amountMinusFee fee greater than maximum");
+        assertLe(trait.amountUSDTWithFee(amount), amount + maximumFee, "amountWithFee fee greater than maximum");
+        assertGe(trait.amountUSDTMinusFee(amount) + maximumFee, amount, "amountMinusFee fee greater than maximum");
 
         // inversion checks
-        assertEq(_amountUSDTMinusFee(_amountUSDTWithFee(amount)), amount, "amountMinusFee not inverse of amountWithFee");
-        assertEq(_amountUSDTWithFee(_amountUSDTMinusFee(amount)), amount, "amountWithFee not inverse of amountMinusFee");
+        assertEq(
+            trait.amountUSDTMinusFee(trait.amountUSDTWithFee(amount)),
+            amount,
+            "amountMinusFee not inverse of amountWithFee"
+        );
+        assertEq(
+            trait.amountUSDTWithFee(trait.amountUSDTMinusFee(amount)),
+            amount,
+            "amountWithFee not inverse of amountMinusFee"
+        );
     }
 }

--- a/contracts/test/unit/traits/USDT_TransferHarness.sol
+++ b/contracts/test/unit/traits/USDT_TransferHarness.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.23;
+
+import {USDT_Transfer} from "../../../traits/USDT_Transfer.sol";
+
+contract USDT_TransferHarness is USDT_Transfer {
+    constructor(address _usdt) USDT_Transfer(_usdt) {}
+
+    function amountUSDTWithFee(uint256 amount) external view returns (uint256) {
+        return _amountUSDTWithFee(amount);
+    }
+
+    function amountUSDTMinusFee(uint256 amount) external view returns (uint256) {
+        return _amountUSDTMinusFee(amount);
+    }
+}

--- a/contracts/traits/ACLTrait.sol
+++ b/contracts/traits/ACLTrait.sol
@@ -7,7 +7,8 @@ import {
     AddressIsNotContractException,
     CallerNotConfiguratorException,
     CallerNotPausableAdminException,
-    CallerNotUnpausableAdminException
+    CallerNotUnpausableAdminException,
+    ZeroAddressException
 } from "../interfaces/IExceptions.sol";
 import {IACL} from "../interfaces/base/IACL.sol";
 import {IACLTrait} from "../interfaces/base/IACLTrait.sol";
@@ -38,7 +39,9 @@ abstract contract ACLTrait is IACLTrait {
 
     /// @notice Constructor
     /// @param  acl_ ACL contract address
+    /// @dev    Reverts if `acl_` is zero address or is not a contract
     constructor(address acl_) {
+        if (acl_ == address(0)) revert ZeroAddressException();
         if (acl_.code.length == 0) revert AddressIsNotContractException(acl_);
         acl = acl_;
     }

--- a/contracts/traits/ContractsRegisterTrait.sol
+++ b/contracts/traits/ContractsRegisterTrait.sol
@@ -6,7 +6,8 @@ pragma solidity ^0.8.23;
 import {
     AddressIsNotContractException,
     RegisteredCreditManagerOnlyException,
-    RegisteredPoolOnlyException
+    RegisteredPoolOnlyException,
+    ZeroAddressException
 } from "../interfaces/IExceptions.sol";
 import {IContractsRegister} from "../interfaces/base/IContractsRegister.sol";
 import {IContractsRegisterTrait} from "../interfaces/base/IContractsRegisterTrait.sol";
@@ -31,7 +32,9 @@ abstract contract ContractsRegisterTrait is IContractsRegisterTrait {
 
     /// @notice Constructor
     /// @param  contractsRegister_ Contracts register contract address
+    /// @dev    Reverts if `contractsRegister_` is zero address or is not a contract
     constructor(address contractsRegister_) {
+        if (contractsRegister_ == address(0)) revert ZeroAddressException();
         if (contractsRegister_.code.length == 0) revert AddressIsNotContractException(contractsRegister_);
         contractsRegister = contractsRegister_;
     }

--- a/contracts/traits/ControlledTrait.sol
+++ b/contracts/traits/ControlledTrait.sol
@@ -24,6 +24,7 @@ abstract contract ControlledTrait is ACLTrait, IControlledTrait {
 
     /// @notice Constructor
     /// @param  acl_ ACL contract address
+    /// @dev    Reverts if `acl_` is zero address or is not a contract
     constructor(address acl_) ACLTrait(acl_) {}
 
     /// @notice Sets new external controller, can only be called by configurator

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,3 @@
-ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 @1inch=lib/@1inch/
 @openzeppelin/=lib/@openzeppelin/


### PR DESCRIPTION
In this PR:
* `PoolQuotaKeeperV3` is now deployed inside `PoolV3`'s constructor, which allows to store it as immutable variable making interactions with the system cheaper
* All the contracts that can read `acl` and `contractsRegister` instead of accepting a constructor argument now do so, reducing the chances of misconfiguration
* Constructors now consistently revert with `ZeroAddressException` 
* Better validation in `USDT_Transfer` trait
* Silence warnings in tests