### PR TITLE
fix: `ColleteralLogic.calcCollateral` no longer decrements token balances by `1`

### DIFF
--- a/contracts/libraries/CollateralLogic.sol
+++ b/contracts/libraries/CollateralLogic.sol
@@ -102,10 +102,7 @@ library CollateralLogic {
     ) internal view returns (uint256 valueUSD, uint256 weightedValueUSD) {
         uint256 balance = IERC20(token).safeBalanceOf(creditAccount);
 
-        if (balance > 1) {
-            unchecked {
-                --balance;
-            }
+        if (balance != 0) {
             valueUSD = convertToUSDFn(priceOracle, balance, token);
             weightedValueUSD = Math.min(valueUSD * liquidationThreshold / PERCENTAGE_FACTOR, quotaUSD);
         }

--- a/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditManagerV3.unit.t.sol
@@ -1681,14 +1681,14 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
                 enabledTokensMask: UNDERLYING_TOKEN_MASK,
                 underlyingBalance: debt,
                 linkBalance: 0,
-                expectedTotalValueUSD: vars.get("UNDERLYING_PRICE") * (debt - 1),
-                expectedTwvUSD: vars.get("UNDERLYING_PRICE") * (debt - 1) * LT_UNDERLYING / PERCENTAGE_FACTOR
+                expectedTotalValueUSD: vars.get("UNDERLYING_PRICE") * debt,
+                expectedTwvUSD: vars.get("UNDERLYING_PRICE") * debt * LT_UNDERLYING / PERCENTAGE_FACTOR
             }),
             CollateralCalcTestCase({
                 name: "One quoted token with balance < quota",
                 enabledTokensMask: LINK_TOKEN_MASK,
                 underlyingBalance: 0,
-                linkBalance: vars.get("LINK_QUOTA") / 2 / vars.get("LINK_PRICE") + 1,
+                linkBalance: vars.get("LINK_QUOTA") / 2 / vars.get("LINK_PRICE"),
                 expectedTotalValueUSD: vars.get("LINK_QUOTA") / 2,
                 expectedTwvUSD: vars.get("LINK_QUOTA") / 2 * vars.get("LINK_LT") / PERCENTAGE_FACTOR
             }),
@@ -1696,7 +1696,7 @@ contract CreditManagerV3UnitTest is TestHelper, ICreditManagerV3Events, BalanceH
                 name: "One quoted token with balance > quota",
                 enabledTokensMask: LINK_TOKEN_MASK,
                 underlyingBalance: 0,
-                linkBalance: 2 * vars.get("LINK_QUOTA") * vars.get("UNDERLYING_PRICE") / vars.get("LINK_PRICE") + 1,
+                linkBalance: 2 * vars.get("LINK_QUOTA") * vars.get("UNDERLYING_PRICE") / vars.get("LINK_PRICE"),
                 expectedTotalValueUSD: 2 * vars.get("LINK_QUOTA_IN_USD"),
                 expectedTwvUSD: vars.get("LINK_QUOTA_IN_USD")
             })

--- a/contracts/test/unit/libraries/CollateralLogic.unit.t.sol
+++ b/contracts/test/unit/libraries/CollateralLogic.unit.t.sol
@@ -45,7 +45,7 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
         CalcOneTokenCollateralTestCase[3] memory cases = [
             CalcOneTokenCollateralTestCase({
                 name: "Balance is zero",
-                balance: 1,
+                balance: 0,
                 price: 0,
                 liquidationThreshold: 80_00,
                 quotaUSD: 0,
@@ -59,8 +59,8 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 price: 2,
                 liquidationThreshold: 80_00,
                 quotaUSD: 10_001,
-                expectedValueUSD: (5_000 - 1) * 2,
-                expectedWeightedValueUSD: (5_000 - 1) * 2 * 80_00 / PERCENTAGE_FACTOR,
+                expectedValueUSD: 5_000 * 2,
+                expectedWeightedValueUSD: 5_000 * 2 * 80_00 / PERCENTAGE_FACTOR,
                 priceOracleCalled: true
             }),
             CalcOneTokenCollateralTestCase({
@@ -69,7 +69,7 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 price: 2,
                 liquidationThreshold: 80_00,
                 quotaUSD: 40_00,
-                expectedValueUSD: (5_000 - 1) * 2,
+                expectedValueUSD: 5_000 * 2,
                 expectedWeightedValueUSD: 40_00,
                 priceOracleCalled: true
             })
@@ -126,9 +126,9 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 balances: arrayOf(B({t: Tokens.USDT, balance: 10_000}), B({t: Tokens.DAI, balance: 5_000})),
                 quotas: arrayOf(Q({t: Tokens.USDT, quota: 10_000})),
                 target: type(uint256).max,
-                expectedTotalValueUSD: (10_000 - 1) * prices[Tokens.USDT] + (5_000 - 1) * prices[Tokens.DAI],
-                expectedTwvUSD: (10_000 - 1) * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR
-                    + (5_000 - 1) * prices[Tokens.DAI] * lts[Tokens.DAI] / PERCENTAGE_FACTOR,
+                expectedTotalValueUSD: 10_000 * prices[Tokens.USDT] + 5_000 * prices[Tokens.DAI],
+                expectedTwvUSD: 10_000 * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR
+                    + 5_000 * prices[Tokens.DAI] * lts[Tokens.DAI] / PERCENTAGE_FACTOR,
                 expectedOrder: arrayOf(Tokens.USDT, Tokens.DAI)
             }),
             CalcCollateralTestCase({
@@ -136,9 +136,9 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 balances: arrayOf(B({t: Tokens.USDT, balance: 10_000}), B({t: Tokens.LINK, balance: 1_000})),
                 quotas: arrayOf(Q({t: Tokens.USDT, quota: 10_000}), Q({t: Tokens.LINK, quota: 20_000})),
                 target: type(uint256).max,
-                expectedTotalValueUSD: (10_000 - 1) * prices[Tokens.USDT] + (1_000 - 1) * prices[Tokens.LINK],
-                expectedTwvUSD: (10_000 - 1) * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR
-                    + (1_000 - 1) * prices[Tokens.LINK] * lts[Tokens.LINK] / PERCENTAGE_FACTOR,
+                expectedTotalValueUSD: 10_000 * prices[Tokens.USDT] + 1_000 * prices[Tokens.LINK],
+                expectedTwvUSD: 10_000 * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR
+                    + 1_000 * prices[Tokens.LINK] * lts[Tokens.LINK] / PERCENTAGE_FACTOR,
                 expectedOrder: arrayOf(Tokens.USDT, Tokens.LINK, Tokens.DAI)
             }),
             CalcCollateralTestCase({
@@ -146,8 +146,8 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 balances: arrayOf(B({t: Tokens.USDT, balance: 10_000}), B({t: Tokens.DAI, balance: 5_000})),
                 quotas: arrayOf(Q({t: Tokens.USDT, quota: 10_000})),
                 target: 8_000 * prices[Tokens.DAI],
-                expectedTotalValueUSD: (10_000 - 1) * prices[Tokens.USDT],
-                expectedTwvUSD: (10_000 - 1) * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR,
+                expectedTotalValueUSD: 10_000 * prices[Tokens.USDT],
+                expectedTwvUSD: 10_000 * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR,
                 expectedOrder: arrayOf(Tokens.USDT)
             }),
             CalcCollateralTestCase({
@@ -155,8 +155,8 @@ contract CollateralLogicUnitTest is TestHelper, CollateralLogicHelper {
                 balances: arrayOf(B({t: Tokens.USDT, balance: 10_000}), B({t: Tokens.LINK, balance: 1_000})),
                 quotas: arrayOf(Q({t: Tokens.USDT, quota: 10_000}), Q({t: Tokens.LINK, quota: 20_000})),
                 target: 8_000 * prices[Tokens.DAI],
-                expectedTotalValueUSD: (10_000 - 1) * prices[Tokens.USDT],
-                expectedTwvUSD: (10_000 - 1) * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR,
+                expectedTotalValueUSD: 10_000 * prices[Tokens.USDT],
+                expectedTwvUSD: 10_000 * prices[Tokens.USDT] * lts[Tokens.USDT] / PERCENTAGE_FACTOR,
                 expectedOrder: arrayOf(Tokens.USDT)
             })
         ];


### PR DESCRIPTION
Fixes https://github.com/spearbit-audits/review-gearbox/issues/23

The fix only addresses the collateral calculation part.

As for withdrawals, keeping 1 unit of a token when a user passes default amount (`type(uint256).max`) is totally fine in terms of security implications while making future interactions with this credit account significantly cheaper. Sophisticated users are totally free to ignore this and pass the desired amount instead. Subtracting `1` in both branches of withdrawal actually makes things worse for those sophisticated users.