### PR TITLE
fix: move LSB calculation inside `BitMask` library

### DIFF
--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -527,7 +527,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ACLNonReentrantTrait {
     function _migrateForbiddenTokens(uint256 forbiddenTokensMask) internal {
         unchecked {
             while (forbiddenTokensMask != 0) {
-                uint256 mask = forbiddenTokensMask & uint256(-int256(forbiddenTokensMask));
+                uint256 mask = forbiddenTokensMask.lsbMask();
                 address token = CreditManagerV3(creditManager).getTokenByMask(mask);
                 _forbidToken(token);
                 forbiddenTokensMask ^= mask;

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -804,7 +804,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
                     if (tokensToCheckMask & tokenMask == 0) continue;
                 } else {
                     // mask with only the LSB of `tokensToCheckMask` enabled
-                    tokenMask = tokensToCheckMask & uint256(-int256(tokensToCheckMask));
+                    tokenMask = tokensToCheckMask.lsbMask();
                 }
 
                 (address token, uint16 lt) = _collateralTokenByMask({tokenMask: tokenMask, calcLT: true}); // U:[CM-24]
@@ -845,7 +845,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
         address _priceOracle = priceOracle;
         uint256 totalValueUSD;
         while (remainingTokensMask != 0) {
-            uint256 tokenMask = remainingTokensMask & uint256(-int256(remainingTokensMask));
+            uint256 tokenMask = remainingTokensMask.lsbMask();
             remainingTokensMask ^= tokenMask;
 
             address token = getTokenByMask(tokenMask);

--- a/contracts/libraries/BalancesLogic.sol
+++ b/contracts/libraries/BalancesLogic.sol
@@ -106,7 +106,7 @@ library BalancesLogic {
         unchecked {
             uint256 i;
             while (tokensMask != 0) {
-                uint256 tokenMask = tokensMask & uint256(-int256(tokensMask));
+                uint256 tokenMask = tokensMask.lsbMask();
                 tokensMask ^= tokenMask;
 
                 address token = getTokenByMaskFn(tokenMask);

--- a/contracts/libraries/BitMask.sol
+++ b/contracts/libraries/BitMask.sol
@@ -70,4 +70,12 @@ library BitMask {
     {
         return (enabledTokensMask | bitsToEnable) & (~bitsToDisable); // U:[BM-5]
     }
+
+    /// @notice Returns a mask with only the least significant bit of `mask` enabled
+    /// @dev This function can be used to efficiently iterate over enabled bits in a mask
+    function lsbMask(uint256 mask) internal pure returns (uint256) {
+        unchecked {
+            return mask & uint256(-int256(mask)); // U:[BM-6]
+        }
+    }
 }

--- a/contracts/libraries/BitMask.sol
+++ b/contracts/libraries/BitMask.sol
@@ -71,7 +71,7 @@ library BitMask {
         return (enabledTokensMask | bitsToEnable) & (~bitsToDisable); // U:[BM-5]
     }
 
-    /// @notice Returns a mask with only the least significant bit of `mask` enabled
+    /// @dev Returns a mask with only the least significant bit of `mask` enabled
     /// @dev This function can be used to efficiently iterate over enabled bits in a mask
     function lsbMask(uint256 mask) internal pure returns (uint256) {
         unchecked {

--- a/contracts/test/unit/libraries/BitMask.unit.t.sol
+++ b/contracts/test/unit/libraries/BitMask.unit.t.sol
@@ -63,4 +63,16 @@ contract BitMaskUnitTest is TestHelper {
         mask = mask.enableDisable(0, 1 << bit);
         assertEq(mask, 0, "Disable doesn't work");
     }
+
+    /// @notice U:[BM-6]: `lsbMask` works correctly
+    function test_U_BM_06_lsbMask_works_correctly(uint256 mask) public {
+        uint256 lsbMask = mask.lsbMask();
+        if (lsbMask == 0) {
+            assertEq(mask, 0, "Zero LSB for non-zero mask");
+            return;
+        }
+        assertEq(lsbMask.calcEnabledTokens(), 1, "LSB mask has more than one enabled bit");
+        assertEq(mask & lsbMask, lsbMask, "LSB is not enabled");
+        assertEq(mask & (lsbMask - 1), 0, "LSB is not least");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/spearbit-audits/review-gearbox/issues/8