### PR TITLE
feat: phantom token withdrawals

### DIFF
--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -22,6 +22,7 @@ import {ICreditConfiguratorV3, AllowanceAction} from "../interfaces/ICreditConfi
 import {IPoolQuotaKeeperV3} from "../interfaces/IPoolQuotaKeeperV3.sol";
 import {IPriceOracleV3} from "../interfaces/IPriceOracleV3.sol";
 import {IAdapter} from "../interfaces/base/IAdapter.sol";
+import {IPhantomToken} from "../interfaces/base/IPhantomToken.sol";
 
 // TRAITS
 import {ControlledTrait} from "../traits/ControlledTrait.sol";
@@ -97,6 +98,9 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, SanityC
     /// @dev Reverts if `token` is underlying
     /// @dev Reverts if `token` is not quoted in the quota keeper
     /// @dev Reverts if `liquidationThreshold` is greater than underlying's LT
+    /// @dev If `token` is a phantom token, reverts if its `depositedToken` is not added to the credit manager
+    /// @dev If `token` is a phantom token, an adapter for its `target` implementing `IPhantomTokenWithdrawer` interface
+    ///       must later be connected in order for withdrawals to work properly
     /// @dev `liquidationThreshold` can be zero to allow users to deposit connector tokens to credit accounts and swap
     ///      them into actual collateral and to withdraw reward tokens sent to credit accounts by integrated protocols
     function addCollateralToken(address token, uint16 liquidationThreshold)
@@ -118,6 +122,10 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, SanityC
         catch {
             revert IncorrectTokenContractException(); // I:[CC-3]
         }
+
+        try IPhantomToken(token).getPhantomTokenInfo() returns (address, address depositedToken) {
+            _getTokenMaskOrRevert(depositedToken); // I:[CC-3]
+        } catch {}
 
         if (IPriceOracleV3(CreditManagerV3(creditManager).priceOracle()).priceFeeds(token) == address(0)) {
             revert PriceFeedDoesNotExistException(); // I:[CC-3]

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -23,10 +23,11 @@ import {
     ICreditManagerV3,
     ManageDebtAction
 } from "../interfaces/ICreditManagerV3.sol";
-import {IDegenNFT} from "../interfaces/base/IDegenNFT.sol";
 import "../interfaces/IExceptions.sol";
 import {IPoolV3} from "../interfaces/IPoolV3.sol";
 import {IPriceOracleV3, PriceUpdate} from "../interfaces/IPriceOracleV3.sol";
+import {IDegenNFT} from "../interfaces/base/IDegenNFT.sol";
+import {IPhantomToken, IPhantomTokenWithdrawer} from "../interfaces/base/IPhantomToken.sol";
 import {IWETH} from "../interfaces/external/IWETH.sol";
 
 // LIBRARIES
@@ -314,7 +315,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
             flags |= SKIP_PRICE_UPDATES_CALL_FLAG;
         }
 
-        (CollateralDebtData memory collateralDebtData, bool isUnhealthy) = _revertIfNotLiquidatable(creditAccount); // U:[FA-13,16]
+        (CollateralDebtData memory collateralDebtData, bool isUnhealthy) = _revertIfNotLiquidatable(creditAccount); // U:[FA-13,14]
 
         BalanceWithMask[] memory initialBalances = BalancesLogic.storeBalances({
             creditAccount: creditAccount,
@@ -322,7 +323,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
             getTokenByMaskFn: _getTokenByMask
         });
 
-        _multicall(creditAccount, calls, collateralDebtData.enabledTokensMask, flags); // U:[FA-16]
+        _multicall(creditAccount, calls, collateralDebtData.enabledTokensMask, flags); // U:[FA-14]
 
         address failedToken = BalancesLogic.compareBalances({
             creditAccount: creditAccount,
@@ -330,9 +331,9 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
             balances: initialBalances,
             comparison: Comparison.LESS_OR_EQUAL
         });
-        if (failedToken != address(0)) revert RemainingTokenBalanceIncreasedException(failedToken); // U:[FA-14]
+        if (failedToken != address(0)) revert RemainingTokenBalanceIncreasedException(failedToken); // U:[FA-14A]
 
-        collateralDebtData.enabledTokensMask = collateralDebtData.enabledTokensMask.enable(UNDERLYING_TOKEN_MASK); // U:[FA-16]
+        collateralDebtData.enabledTokensMask = collateralDebtData.enabledTokensMask.enable(UNDERLYING_TOKEN_MASK); // U:[FA-14]
 
         uint256 remainingFunds;
         (remainingFunds, reportedLoss) = ICreditManagerV3(creditManager).liquidateCreditAccount({
@@ -340,9 +341,9 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
             collateralDebtData: collateralDebtData,
             to: to,
             isExpired: !isUnhealthy
-        }); // U:[FA-15,16]
+        }); // U:[FA-14]
 
-        emit LiquidateCreditAccount(creditAccount, msg.sender, to, remainingFunds); // U:[FA-16]
+        emit LiquidateCreditAccount(creditAccount, msg.sender, to, remainingFunds); // U:[FA-14]
 
         if (reportedLoss != 0) {
             maxDebtPerBlockMultiplier = 0; // U:[FA-17]
@@ -357,7 +358,8 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     /// @notice Partially liquidates credit account's debt in exchange for discounted collateral
     ///         - Updates price feeds before running all computations
     ///         - Evaluates account's collateral and debt to determine whether liquidated account is unhealthy or expired
-    ///         - Transfers underlying from the caller and uses it to repay account's debt and pay fees to the treasury
+    ///         - Transfers underlying from the caller (requires approval to the credit manager) and uses it to repay
+    ///           account's debt and pay fees to the treasury
     ///         - Transfers chosen collateral token at discounted oracle price to the liquidator (liquidation discount
     ///         and fee are the same as for full liquidations, though fees are not deposited into the pool)
     ///         - Runs the collateral check
@@ -368,12 +370,14 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     /// @param to Account to withdraw seized `token` to
     /// @param priceUpdates On-demand price feed updates to apply before calculations, see `PriceUpdate` for details
     /// @return seizedAmount Amount of `token` seized
-    /// @dev When the credit facade is paused, reverts if caller is not an approved emergency liquidator
+    /// @dev If facade is paused, reverts if caller is not an approved emergency liquidator or the loss liquidator
     /// @dev Reverts if `creditAccount` is not opened in connected credit manager
     /// @dev Reverts if account has no debt or is neither unhealthy nor expired
-    /// @dev Reverts if `token` is underlying
-    /// @dev Like in full liquidations, liquidator can seize non-enabled tokens from the credit account, altough
-    ///      here they are actually used to repay debt; unclaimed rewards are also safe in this case
+    /// @dev Reverts if `token` is underlying or if `token` is a phantom token and its `depositedToken` is underlying
+    /// @dev If `token` is a phantom token, it's withdrawn first, and its `depositedToken` is then sent to the liquidator.
+    ///      Both `seizedAmount` and `minSeizedAmount` refer to `depositedToken` in this case.
+    /// @dev Like in full liquidations, liquidator can seize non-enabled tokens from the credit account, altough here
+    ///      they are actually used to repay debt. Unclaimed rewards are safe since adapter calls are not allowed.
     function partiallyLiquidateCreditAccount(
         address creditAccount,
         address token,
@@ -384,37 +388,41 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     )
         external
         override
-        whenNotPausedOrEmergency // U:[FA-2]
+        whenNotPausedOrEmergency // U:[FA-2,12]
         nonReentrant // U:[FA-4]
         returns (uint256 seizedAmount)
     {
         address priceOracle = _priceOracle();
         if (priceUpdates.length != 0) _updatePrices(priceOracle, priceUpdates);
 
-        if (token == underlying) revert UnderlyingIsNotLiquidatableException();
-        (CollateralDebtData memory cdd, bool isUnhealthy) = _revertIfNotLiquidatable(creditAccount);
+        (CollateralDebtData memory cdd, bool isUnhealthy) = _revertIfNotLiquidatable(creditAccount); // U:[FA-13,16]
 
         uint256 balanceBefore = IERC20(underlying).safeBalanceOf(creditAccount);
-        _addCollateral(creditAccount, underlying, repaidAmount);
+        _addCollateral(creditAccount, underlying, repaidAmount); // U:[FA-16]
         repaidAmount = IERC20(underlying).safeBalanceOf(creditAccount) - balanceBefore;
 
         uint256 feeAmount;
         (repaidAmount, feeAmount, seizedAmount) =
-            _calcPartialLiquidationPayments(repaidAmount, token, priceOracle, !isUnhealthy);
-        if (seizedAmount < minSeizedAmount) revert SeizedLessThanRequiredException(seizedAmount);
+            _calcPartialLiquidationPayments(repaidAmount, token, priceOracle, !isUnhealthy); // U:[FA-15]
 
-        _manageDebt(creditAccount, repaidAmount, cdd.enabledTokensMask, ManageDebtAction.DECREASE_DEBT);
-        _withdrawCollateral(creditAccount, underlying, feeAmount, treasury);
-        _withdrawCollateral(creditAccount, token, seizedAmount, to);
+        uint256 flags;
+        (token, seizedAmount, flags) = _tryWithdrawPhantomToken(creditAccount, token, seizedAmount, 0); // U:[FA-16A]
+        if (token == underlying) revert UnderlyingIsNotLiquidatableException(); // U:[FA-16,16A]
+        if (seizedAmount < minSeizedAmount) revert SeizedLessThanRequiredException(seizedAmount); // U:[FA-16,16A]
+        if (flags & EXTERNAL_CONTRACT_WAS_CALLED_FLAG != 0) _unsetActiveCreditAccount(); // U:[FA-16A]
+
+        _manageDebt(creditAccount, repaidAmount, cdd.enabledTokensMask, ManageDebtAction.DECREASE_DEBT); // U:[FA-16]
+        _withdrawCollateral(creditAccount, underlying, feeAmount, treasury); // U:[FA-16]
+        _withdrawCollateral(creditAccount, token, seizedAmount, to); // U:[FA-16]
         _fullCollateralCheck({
             creditAccount: creditAccount,
             enabledTokensMask: cdd.enabledTokensMask,
             collateralHints: new uint256[](0),
             minHealthFactor: PERCENTAGE_FACTOR,
             useSafePrices: false
-        });
+        }); // U:[FA-16]
 
-        emit PartiallyLiquidateCreditAccount(creditAccount, token, msg.sender, repaidAmount, seizedAmount, feeAmount);
+        emit PartiallyLiquidateCreditAccount(creditAccount, token, msg.sender, repaidAmount, seizedAmount, feeAmount); // U:[FA-16]
     }
 
     /// @notice Executes a batch of calls allowing user to manage their credit account
@@ -546,8 +554,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
                     // withdrawCollateral
                     else if (method == ICreditFacadeV3Multicall.withdrawCollateral.selector) {
                         _revertIfNoPermission(flags, WITHDRAW_COLLATERAL_PERMISSION); // U:[FA-21]
-                        _withdrawCollateral(creditAccount, mcall.callData[4:]); // U:[FA-36]
-                        flags |= REVERT_ON_FORBIDDEN_TOKENS_FLAG | USE_SAFE_PRICES_FLAG; // U:[FA-36,45]
+                        flags = _withdrawCollateral(creditAccount, mcall.callData[4:], flags); // U:[FA-36]
                     }
                     // increaseDebt
                     else if (method == ICreditFacadeV3Multicall.increaseDebt.selector) {
@@ -580,17 +587,13 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
                 // adapter calls
                 else {
                     _revertIfNoPermission(flags, EXTERNAL_CALLS_PERMISSION); // U:[FA-21]
-                    address targetContract = ICreditManagerV3(creditManager).adapterToContract(mcall.target);
-                    if (targetContract == address(0)) {
-                        revert TargetContractNotAllowedException();
-                    }
-                    if (flags & EXTERNAL_CONTRACT_WAS_CALLED_FLAG == 0) {
-                        flags |= EXTERNAL_CONTRACT_WAS_CALLED_FLAG;
-                        _setActiveCreditAccount(creditAccount); // U:[FA-38]
-                    }
-                    bool useSafePrices = abi.decode(mcall.target.functionCall(mcall.callData), (bool)); // U:[FA-38]
-                    if (useSafePrices) flags |= REVERT_ON_FORBIDDEN_TOKENS_FLAG | USE_SAFE_PRICES_FLAG; // U:[FA-38,45]
-                    emit Execute({creditAccount: creditAccount, targetContract: targetContract});
+                    flags = _externalCall({
+                        creditAccount: creditAccount,
+                        target: ICreditManagerV3(creditManager).adapterToContract(mcall.target),
+                        adapter: mcall.target,
+                        callData: mcall.callData,
+                        flags: flags
+                    }); // U:[FA-38]
                 }
             }
         }
@@ -726,7 +729,10 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     }
 
     /// @dev `ICreditFacadeV3Multicall.withdrawCollateral` implementation
-    function _withdrawCollateral(address creditAccount, bytes calldata callData) internal {
+    function _withdrawCollateral(address creditAccount, bytes calldata callData, uint256 flags)
+        internal
+        returns (uint256)
+    {
         (address token, uint256 amount, address to) = abi.decode(callData, (address, uint256, address)); // U:[FA-36]
 
         if (amount == type(uint256).max) {
@@ -739,7 +745,9 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
         }
         if (amount == 0) revert AmountCantBeZeroException(); // U:[FA-36]
 
+        (token, amount, flags) = _tryWithdrawPhantomToken(creditAccount, token, amount, flags); // U:[FA-36A]
         _withdrawCollateral(creditAccount, token, amount, to); // U:[FA-36]
+        return flags | REVERT_ON_FORBIDDEN_TOKENS_FLAG | USE_SAFE_PRICES_FLAG; // U:[FA-36,45]
     }
 
     /// @dev `ICreditFacadeV3Multicall.setBotPermissions` implementation
@@ -758,6 +766,48 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
         } else if (_flagsOf(creditAccount) & BOT_PERMISSIONS_SET_FLAG == 0) {
             _setFlagFor({creditAccount: creditAccount, flag: BOT_PERMISSIONS_SET_FLAG, value: true}); // U:[FA-37]
         }
+    }
+
+    /// @dev Phantom token withdrawal implementation
+    function _tryWithdrawPhantomToken(address creditAccount, address token, uint256 amount, uint256 flags)
+        internal
+        returns (address, uint256, uint256)
+    {
+        try IPhantomToken(token).getPhantomTokenInfo() returns (address target, address depositedToken) {
+            // ensure that `token` is recognized by the credit manager
+            _getTokenMaskOrRevert(token); // U:[FA-36A]
+
+            uint256 balanceBefore = IERC20(depositedToken).safeBalanceOf(creditAccount);
+            flags = _externalCall({
+                creditAccount: creditAccount,
+                target: target,
+                adapter: ICreditManagerV3(creditManager).contractToAdapter(target),
+                callData: abi.encodeCall(IPhantomTokenWithdrawer.withdrawPhantomToken, (token, amount)),
+                flags: flags
+            }); // U:[FA-36A]
+
+            emit WithdrawPhantomToken(creditAccount, token, amount); // U:[FA-36A]
+            return (depositedToken, IERC20(depositedToken).safeBalanceOf(creditAccount) - balanceBefore, flags);
+        } catch {
+            return (token, amount, flags);
+        }
+    }
+
+    /// @dev Adapter call implementation
+    function _externalCall(address creditAccount, address target, address adapter, bytes memory callData, uint256 flags)
+        internal
+        returns (uint256)
+    {
+        if (adapter == address(0) || target == address(0)) revert TargetContractNotAllowedException(); // U:[FA-38]
+
+        if (flags & EXTERNAL_CONTRACT_WAS_CALLED_FLAG == 0) _setActiveCreditAccount(creditAccount); // U:[FA-38]
+        flags |= EXTERNAL_CONTRACT_WAS_CALLED_FLAG;
+
+        bool useSafePrices = abi.decode(adapter.functionCall(callData), (bool)); // U:[FA-38]
+        if (useSafePrices) flags |= REVERT_ON_FORBIDDEN_TOKENS_FLAG | USE_SAFE_PRICES_FLAG; // U:[FA-38,45]
+
+        emit Execute({creditAccount: creditAccount, targetContract: target}); // U:[FA-38]
+        return flags;
     }
 
     // ------------- //
@@ -922,18 +972,18 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
         returns (CollateralDebtData memory cdd, bool isUnhealthy)
     {
         cdd = ICreditManagerV3(creditManager).calcDebtAndCollateral(creditAccount, CollateralCalcTask.DEBT_COLLATERAL);
-        isUnhealthy = cdd.twvUSD < cdd.totalDebtUSD;
-        if (cdd.debt == 0 || !isUnhealthy && !_isExpired()) revert CreditAccountNotLiquidatableException();
+        isUnhealthy = cdd.twvUSD < cdd.totalDebtUSD; // U:[FA-13]
+        if (cdd.debt == 0 || !isUnhealthy && !_isExpired()) revert CreditAccountNotLiquidatableException(); // U:[FA-13]
     }
 
     /// @dev Calculates and returns partial liquidation payment amounts:
     ///      - amount of underlying that should go towards repaying debt
     ///      - amount of underlying that should go towards liquidation fees
     ///      - amount of collateral that should be sent to the liquidator
-    function _calcPartialLiquidationPayments(uint256 repaidAmount, address token, address priceOracle, bool isExpired)
+    function _calcPartialLiquidationPayments(uint256 amount, address token, address priceOracle, bool isExpired)
         internal
         view
-        returns (uint256 repaidAmount_, uint256 feeAmount, uint256 seizedAmount)
+        returns (uint256 repaidAmount, uint256 feeAmount, uint256 seizedAmount)
     {
         (
             ,
@@ -942,11 +992,12 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
             uint16 feeLiquidationExpired,
             uint16 liquidationDiscountExpired
         ) = ICreditManagerV3(creditManager).fees();
-        seizedAmount = IPriceOracleV3(priceOracle).convert(repaidAmount, underlying, token) * PERCENTAGE_FACTOR
-            / (isExpired ? liquidationDiscountExpired : liquidationDiscount);
-        feeAmount = repaidAmount * (isExpired ? feeLiquidationExpired : feeLiquidation) / PERCENTAGE_FACTOR;
+        seizedAmount = IPriceOracleV3(priceOracle).convert(amount, underlying, token) * PERCENTAGE_FACTOR
+            / (isExpired ? liquidationDiscountExpired : liquidationDiscount); // U:[FA-15]
+        feeAmount = amount * (isExpired ? feeLiquidationExpired : feeLiquidation) / PERCENTAGE_FACTOR; // U:[FA-15]
         unchecked {
-            repaidAmount_ = repaidAmount - feeAmount;
+            // unchecked subtraction is safe because credit configurator ensures that liquidation fee is below 100%
+            repaidAmount = amount - feeAmount; // U:[FA-15]
         }
     }
 

--- a/contracts/interfaces/ICreditFacadeV3.sol
+++ b/contracts/interfaces/ICreditFacadeV3.sol
@@ -67,6 +67,9 @@ interface ICreditFacadeV3Events {
     /// @notice Emitted when a multicall is started
     event StartMultiCall(address indexed creditAccount, address indexed caller);
 
+    /// @notice Emitted when phantom token is withdrawn by account
+    event WithdrawPhantomToken(address indexed creditAccount, address indexed token, uint256 amount);
+
     /// @notice Emitted when a call from account to an external contract is made during a multicall
     event Execute(address indexed creditAccount, address indexed targetContract);
 

--- a/contracts/interfaces/ICreditFacadeV3Multicall.sol
+++ b/contracts/interfaces/ICreditFacadeV3Multicall.sol
@@ -135,6 +135,8 @@ interface ICreditFacadeV3Multicall {
     /// @dev This method can also be called during liquidation
     /// @dev Withdrawals are prohibited in multicalls if there are forbidden tokens enabled as collateral on the account
     /// @dev Withdrawals activate safe pricing (min of main and reserve feeds) in collateral check
+    /// @dev If `token` is a phantom token, it's withdrawn first, and its `depositedToken` is then sent to the recipient.
+    ///      Although an adapter call is made in process, permission for external calls is not required.
     function withdrawCollateral(address token, uint256 amount, address to) external;
 
     /// @notice Sets advanced collateral check parameters

--- a/contracts/interfaces/base/IPhantomToken.sol
+++ b/contracts/interfaces/base/IPhantomToken.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.17;
+
+import {IVersion} from "./IVersion.sol";
+
+/// @title Phantom token interface
+/// @notice Broadly speaking, by saying "phantom" we imply that token is not transferable. In Gearbox, we use such tokens
+///         to track balances of non-tokenized positions in integrated protocols to allow those to be used as collateral.
+interface IPhantomToken is IVersion {
+    /// @notice Returns phantom token's target contract and deposited token
+    function getPhantomTokenInfo() external view returns (address target, address depositedToken);
+}
+
+/// @title Phantom token withdrawer interface
+/// @notice Though only the `balanceOf()` function is needed for token to serve as collateral, some services can suffer
+///         from its non-transferability, including liquidators or bots that don't have permissions for external calls.
+///         To mitigate this, phantom token withdrawals from credit accounts automatically start with withdrawal of
+///         deposited token from the integrated protocol via an adapter call defined by this interface.
+/// @dev While theoretically possible, we assume that phantom tokens can't be nested
+interface IPhantomTokenWithdrawer {
+    /// @notice Withdraws phantom token for its deposited token
+    function withdrawPhantomToken(address token, uint256 amount) external returns (bool useSafePrices);
+}

--- a/contracts/test/integration/credit/CreditConfigurator.int.t.sol
+++ b/contracts/test/integration/credit/CreditConfigurator.int.t.sol
@@ -31,6 +31,7 @@ import {TargetContractMock} from "../../mocks/core/TargetContractMock.sol";
 import {CreditFacadeV3Harness} from "../../unit/credit/CreditFacadeV3Harness.sol";
 import {IntegrationTestHelper} from "../../helpers/IntegrationTestHelper.sol";
 import {FlagState, PriceFeedMock} from "../../mocks/oracles/PriceFeedMock.sol";
+import {PhantomTokenMock} from "../../mocks/token/PhantomTokenMock.sol";
 
 // SUITES
 import {TokensTestSuite} from "../../suites/TokensTestSuite.sol";
@@ -288,6 +289,11 @@ contract CreditConfiguratorIntegrationTest is IntegrationTestHelper, ICreditConf
         address nonQuotedToken = tokenTestSuite.addressOf(Tokens.wstETH);
         vm.expectRevert(TokenIsNotQuotedException.selector);
         creditConfigurator.addCollateralToken(nonQuotedToken, 9300);
+
+        address phantomToken = address(new PhantomTokenMock(address(0), address(0), "Test Token", "TEST"));
+        priceOracle.setPriceFeed(phantomToken, address(new PriceFeedMock(1e8, 8)), 1);
+        vm.expectRevert(TokenNotAllowedException.selector);
+        creditConfigurator.addCollateralToken(phantomToken, 9300);
 
         vm.stopPrank();
     }

--- a/contracts/test/mocks/credit/CreditManagerMock.sol
+++ b/contracts/test/mocks/credit/CreditManagerMock.sol
@@ -3,7 +3,8 @@
 // (c) Gearbox Foundation, 2023.
 pragma solidity ^0.8.17;
 
-import "../../interfaces/IAddressProviderV3.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {
     ICreditManagerV3,
@@ -15,9 +16,12 @@ import {IPoolV3} from "../../../interfaces/IPoolV3.sol";
 
 import "../../../interfaces/IExceptions.sol";
 
+import "../../../libraries/Constants.sol";
 import "../../lib/constants.sol";
 
 contract CreditManagerMock {
+    using SafeERC20 for IERC20;
+
     /// @dev Factory contract for Credit Accounts
     address public addressProvider;
 
@@ -40,7 +44,6 @@ contract CreditManagerMock {
     CollateralDebtData return_collateralDebtData;
 
     CollateralDebtData _liquidateCollateralDebtData;
-    bool _liquidateIsExpired;
     uint256 internal _enabledTokensMask;
 
     address nextCreditAccount;
@@ -68,6 +71,8 @@ contract CreditManagerMock {
     uint256 qu_tokensToDisable;
 
     uint256 sw_tokensToDisable;
+
+    bool _transfersActivated;
 
     constructor(address _addressProvider, address _pool) {
         addressProvider = _addressProvider;
@@ -147,12 +152,11 @@ contract CreditManagerMock {
 
     function closeCreditAccount(address) external {}
 
-    function liquidateCreditAccount(address, CollateralDebtData memory collateralDebtData, address, bool isExpired)
+    function liquidateCreditAccount(address, CollateralDebtData memory collateralDebtData, address, bool)
         external
         returns (uint256 remainingFunds, uint256 loss)
     {
         _liquidateCollateralDebtData = collateralDebtData;
-        _liquidateIsExpired = isExpired;
         remainingFunds = return_remainingFunds;
         loss = return_loss;
     }
@@ -173,6 +177,11 @@ contract CreditManagerMock {
         activeCreditAccount = creditAccount;
     }
 
+    function getActiveCreditAccountOrRevert() external view returns (address) {
+        if (revertOnSetActiveAccount) revert ActiveCreditAccountNotSetException();
+        return activeCreditAccount;
+    }
+
     function setQuotedTokensMask(uint256 _quotedTokensMask) external {
         quotedTokensMask = _quotedTokensMask;
     }
@@ -187,10 +196,6 @@ contract CreditManagerMock {
 
     function liquidateCollateralDebtData() external view returns (CollateralDebtData memory) {
         return _liquidateCollateralDebtData;
-    }
-
-    function liquidateIsExpired() external view returns (bool) {
-        return _liquidateIsExpired;
     }
 
     function enabledTokensMaskOf(address) external view returns (uint256) {
@@ -239,10 +244,6 @@ contract CreditManagerMock {
         flags &= ~flag; // U:[CM-36]
     }
 
-    function addCollateral(address, address, address, uint256) external pure returns (uint256) {
-        return 0;
-    }
-
     function setManageDebt(uint256 newDebt) external {
         return_newDebt = newDebt;
     }
@@ -255,7 +256,37 @@ contract CreditManagerMock {
         return (return_newDebt, 0, 0);
     }
 
-    function withdrawCollateral(address, address, uint256, address) external pure returns (uint256) {
+    function activateTransfers() external {
+        _transfersActivated = true;
+    }
+
+    function deactivateTransfers() external {
+        _transfersActivated = false;
+    }
+
+    function addCollateral(address payer, address creditAccount, address token, uint256 amount)
+        external
+        returns (uint256)
+    {
+        if (_transfersActivated) IERC20(token).safeTransferFrom(payer, creditAccount, amount);
         return 0;
+    }
+
+    function withdrawCollateral(address creditAccount, address token, uint256 amount, address to)
+        external
+        returns (uint256)
+    {
+        if (_transfersActivated) IERC20(token).safeTransferFrom(creditAccount, to, amount);
+        return 0;
+    }
+
+    function fees() external pure returns (uint16, uint16, uint16, uint16, uint16) {
+        return (
+            DEFAULT_FEE_INTEREST,
+            DEFAULT_FEE_LIQUIDATION,
+            PERCENTAGE_FACTOR - DEFAULT_LIQUIDATION_PREMIUM,
+            DEFAULT_FEE_LIQUIDATION_EXPIRED,
+            PERCENTAGE_FACTOR - DEFAULT_LIQUIDATION_PREMIUM_EXPIRED
+        );
     }
 }

--- a/contracts/test/mocks/token/PhantomTokenMock.sol
+++ b/contracts/test/mocks/token/PhantomTokenMock.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.17;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ICreditManagerV3} from "../../../interfaces/ICreditManagerV3.sol";
+import {NotImplementedException} from "../../../interfaces/IExceptions.sol";
+import {IAdapter} from "../../../interfaces/base/IAdapter.sol";
+import {IPhantomToken, IPhantomTokenWithdrawer} from "../../../interfaces/base/IPhantomToken.sol";
+import {ERC20Mock} from "../token/ERC20Mock.sol";
+
+contract PhantomTokenMock is IPhantomToken, ERC20 {
+    uint256 public constant override version = 3_10;
+    bytes32 public constant override contractType = "PT_MOCK";
+
+    address public immutable target;
+    address public immutable depositedToken;
+
+    uint256 public exchangeRate = 1e18;
+
+    constructor(address target_, address depositedToken_, string memory name_, string memory symbol_)
+        ERC20(name_, symbol_)
+    {
+        target = target_;
+        depositedToken = depositedToken_;
+    }
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert NotImplementedException();
+    }
+
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        revert NotImplementedException();
+    }
+
+    function getPhantomTokenInfo() external view override returns (address, address) {
+        return (target, depositedToken);
+    }
+
+    function setExchangeRate(uint256 value) external {
+        exchangeRate = value;
+    }
+}
+
+contract PhantomTokenWithdrawerMock is IAdapter, IPhantomTokenWithdrawer {
+    uint256 public constant override version = 3_10;
+    bytes32 public constant override contractType = "AD_PHANTOM_TOKEN_WITHDRAWER_MOCK";
+
+    address public immutable override creditManager;
+    address public immutable override targetContract;
+
+    address public immutable phantomToken;
+    address public immutable depositedToken;
+
+    constructor(address creditManager_, address phantomToken_) {
+        creditManager = creditManager_;
+        phantomToken = phantomToken_;
+        (targetContract, depositedToken) = IPhantomToken(phantomToken_).getPhantomTokenInfo();
+    }
+
+    function withdrawPhantomToken(address, uint256 amount) external override returns (bool) {
+        address creditAccount = ICreditManagerV3(creditManager).getActiveCreditAccountOrRevert();
+        PhantomTokenMock(phantomToken).burn(creditAccount, amount);
+        ERC20Mock(depositedToken).mint(creditAccount, amount * PhantomTokenMock(phantomToken).exchangeRate() / 1e18);
+        return false;
+    }
+}

--- a/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3.unit.t.sol
@@ -8,6 +8,7 @@ import {AddressProviderV3ACLMock} from "../../mocks/core/AddressProviderV3ACLMoc
 
 import {ERC20Mock} from "../../mocks/token/ERC20Mock.sol";
 import {ERC20PermitMock} from "../../mocks/token/ERC20PermitMock.sol";
+import {PhantomTokenMock, PhantomTokenWithdrawerMock} from "../../mocks/token/PhantomTokenMock.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 
 /// LIBS
@@ -47,7 +48,8 @@ import {
     BOT_PERMISSIONS_SET_FLAG,
     DEFAULT_LIMIT_PER_BLOCK_MULTIPLIER,
     PERCENTAGE_FACTOR,
-    UNDERLYING_TOKEN_MASK
+    UNDERLYING_TOKEN_MASK,
+    INACTIVE_CREDIT_ACCOUNT_ADDRESS
 } from "../../../libraries/Constants.sol";
 
 // TESTS
@@ -461,10 +463,18 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         address creditAccount = DUMB_ADDRESS;
         creditManagerMock.setBorrower(USER);
 
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+        creditManagerMock.addToken(link, 1 << 1);
+
+        priceOracleMock.setPrice(dai, 1e8);
+        priceOracleMock.setPrice(link, 1e8);
+        creditManagerMock.setPriceOracle(address(priceOracleMock));
+
         CollateralDebtData memory collateralDebtData;
         collateralDebtData.debt = 101;
         collateralDebtData.totalDebtUSD = 101;
-        collateralDebtData.twvUSD = 100;
+        collateralDebtData.twvUSD = 102;
         creditManagerMock.setDebtAndCollateralData(collateralDebtData);
 
         vm.prank(CONFIGURATOR);
@@ -473,8 +483,20 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         vm.prank(CONFIGURATOR);
         creditFacade.setEmergencyLiquidator(LIQUIDATOR, AllowanceAction.ALLOW);
 
+        vm.expectRevert(CreditAccountNotLiquidatableException.selector);
         vm.prank(LIQUIDATOR);
         creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
+
+        vm.expectRevert(CreditAccountNotLiquidatableException.selector);
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: link,
+            repaidAmount: 0,
+            minSeizedAmount: 0,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
 
         vm.prank(CONFIGURATOR);
         creditFacade.setEmergencyLiquidator(LIQUIDATOR, AllowanceAction.FORBID);
@@ -482,17 +504,40 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         vm.expectRevert("Pausable: paused");
         vm.prank(LIQUIDATOR);
         creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
+
+        vm.expectRevert("Pausable: paused");
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: link,
+            repaidAmount: 0,
+            minSeizedAmount: 0,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
     }
 
     /// @dev U:[FA-13]: liquidateCreditAccount reverts if account is not liquidatable
-    function test_U_FA_13_liquidateCreditAccount_reverts_if_account_is_not_liquidatable() public allExpirableCases {
+    function test_U_FA_13_revertIfNotLiquidatable_works_as_expected() public allExpirableCases {
         address creditAccount = DUMB_ADDRESS;
         creditManagerMock.setBorrower(USER);
 
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+        creditManagerMock.addToken(link, 1 << 1);
+
+        priceOracleMock.setPrice(dai, 1e8);
+        priceOracleMock.setPrice(link, 1e8);
+        creditManagerMock.setPriceOracle(address(priceOracleMock));
+
+        if (expirable) {
+            vm.prank(CONFIGURATOR);
+            creditFacade.setExpirationDate(uint40(block.timestamp + 1));
+        }
+
         // no debt
         vm.expectRevert(CreditAccountNotLiquidatableException.selector);
-        vm.prank(LIQUIDATOR);
-        creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
+        creditFacade.revertIfNotLiquidatable(creditAccount);
 
         // healthy, non-expired
         CollateralDebtData memory collateralDebtData;
@@ -501,108 +546,35 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         collateralDebtData.twvUSD = 101;
         creditManagerMock.setDebtAndCollateralData(collateralDebtData);
 
-        if (expirable) {
-            vm.prank(CONFIGURATOR);
-            creditFacade.setExpirationDate(uint40(block.timestamp + 1));
-        }
-
         vm.expectRevert(CreditAccountNotLiquidatableException.selector);
-        vm.prank(LIQUIDATOR);
-        creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
-    }
-
-    /// @dev U:[FA-14]: liquidateCreditAccount reverts if non-underlying balance increases in multicall
-    function test_U_FA_14_liquidateCreditAccount_reverts_if_non_underlying_balance_increases_in_multicall()
-        public
-        notExpirableCase
-    {
-        address dai = tokenTestSuite.addressOf(Tokens.DAI);
-        address link = tokenTestSuite.addressOf(Tokens.LINK);
-        uint256 linkMask = 4;
-        creditManagerMock.addToken(link, linkMask);
-
-        AdapterCallMock adapter = new AdapterCallMock();
-        creditManagerMock.setContractAllowance(address(adapter), makeAddr("DUMMY"));
-        ERC20Mock(dai).set_minter(address(adapter));
-        ERC20Mock(link).set_minter(address(adapter));
-
-        address creditAccount = DUMB_ADDRESS;
-        creditManagerMock.setBorrower(USER);
-
-        deal({token: dai, to: creditAccount, give: 50});
-        deal({token: link, to: creditAccount, give: 50});
-
-        CollateralDebtData memory collateralDebtData;
-        collateralDebtData.debt = 101;
-        collateralDebtData.totalDebtUSD = 101;
-        collateralDebtData.twvUSD = 100;
-        collateralDebtData.enabledTokensMask = UNDERLYING_TOKEN_MASK | linkMask;
-        creditManagerMock.setDebtAndCollateralData(collateralDebtData);
-
-        for (uint256 i; i < 2; ++i) {
-            bool addNonUnderlying = i == 1;
-            if (addNonUnderlying) {
-                vm.expectRevert(abi.encodeWithSelector(RemainingTokenBalanceIncreasedException.selector, (link)));
-            }
-
-            vm.prank(LIQUIDATOR);
-            creditFacade.liquidateCreditAccount({
-                creditAccount: creditAccount,
-                to: FRIEND,
-                calls: MultiCallBuilder.build(
-                    MultiCall(
-                        address(adapter),
-                        abi.encodeCall(
-                            AdapterCallMock.makeCall,
-                            (addNonUnderlying ? link : dai, abi.encodeCall(ERC20Mock.mint, (creditAccount, 10)))
-                        )
-                    )
-                )
-            });
-        }
-    }
-
-    /// @dev U:[FA-15]: liquidateCreditAccount correctly determines liquidation type
-    function test_U_FA_15_liquidateCreditAccount_correctly_determines_liquidation_type() public allExpirableCases {
-        address creditAccount = DUMB_ADDRESS;
-        creditManagerMock.setBorrower(USER);
-
-        CollateralDebtData memory collateralDebtData;
-        collateralDebtData.debt = 101;
-        collateralDebtData.totalDebtUSD = 101;
+        creditFacade.revertIfNotLiquidatable(creditAccount);
 
         // unhealthy, non-expired
         collateralDebtData.twvUSD = 100;
         creditManagerMock.setDebtAndCollateralData(collateralDebtData);
 
-        vm.prank(LIQUIDATOR);
-        creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
-        assertFalse(creditManagerMock.liquidateIsExpired(), "isExpired on unhealthy non-expired liquidation");
+        (, bool isUnhealthy) = creditFacade.revertIfNotLiquidatable(creditAccount);
+        assertTrue(isUnhealthy, "isUnhealthy is incorrectly false (unhealthy non-expired case)");
 
-        if (expirable) {
-            vm.prank(CONFIGURATOR);
-            creditFacade.setExpirationDate(uint40(block.timestamp - 1));
+        if (!expirable) return;
 
-            // healthy, expired
-            collateralDebtData.twvUSD = 101;
-            creditManagerMock.setDebtAndCollateralData(collateralDebtData);
+        // unhealthy, expired
+        vm.prank(CONFIGURATOR);
+        creditFacade.setExpirationDate(uint40(block.timestamp - 1));
 
-            vm.prank(LIQUIDATOR);
-            creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
-            assertTrue(creditManagerMock.liquidateIsExpired(), "isExpired on healthy expired liquidation");
+        (, isUnhealthy) = creditFacade.revertIfNotLiquidatable(creditAccount);
+        assertTrue(isUnhealthy, "isUnhealthy is incorrectly false (unhealthy expired case)");
 
-            // unhealthy, expired
-            collateralDebtData.twvUSD = 100;
-            creditManagerMock.setDebtAndCollateralData(collateralDebtData);
+        // healthy, expired
+        collateralDebtData.twvUSD = 101;
+        creditManagerMock.setDebtAndCollateralData(collateralDebtData);
 
-            vm.prank(LIQUIDATOR);
-            creditFacade.liquidateCreditAccount({creditAccount: creditAccount, to: FRIEND, calls: new MultiCall[](0)});
-            assertFalse(creditManagerMock.liquidateIsExpired(), "isExpired on unhealthy expired liquidation");
-        }
+        (, isUnhealthy) = creditFacade.revertIfNotLiquidatable(creditAccount);
+        assertFalse(isUnhealthy, "isUnhealthy is incorrectly true (healthy expired case)");
     }
 
-    /// @dev U:[FA-16]: liquidateCreditAccount works as expected
-    function test_U_FA_16_liquidateCreditAccount_works_as_expected() public notExpirableCase {
+    /// @dev U:[FA-14]: liquidateCreditAccount works as expected
+    function test_U_FA_14_liquidateCreditAccount_works_as_expected() public notExpirableCase {
         address creditAccount = DUMB_ADDRESS;
         creditManagerMock.setBorrower(USER);
 
@@ -650,6 +622,309 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
             )
         });
         assertEq(loss, 0, "Non-zero loss");
+    }
+
+    /// @dev U:[FA-14A]: liquidateCreditAccount reverts if non-underlying balance increases in multicall
+    function test_U_FA_14A_liquidateCreditAccount_reverts_if_non_underlying_balance_increases_in_multicall()
+        public
+        notExpirableCase
+    {
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+        uint256 linkMask = 4;
+        creditManagerMock.addToken(link, linkMask);
+
+        AdapterCallMock adapter = new AdapterCallMock();
+        creditManagerMock.setContractAllowance(address(adapter), makeAddr("DUMMY"));
+        ERC20Mock(dai).set_minter(address(adapter));
+        ERC20Mock(link).set_minter(address(adapter));
+
+        address creditAccount = DUMB_ADDRESS;
+        creditManagerMock.setBorrower(USER);
+
+        deal({token: dai, to: creditAccount, give: 50});
+        deal({token: link, to: creditAccount, give: 50});
+
+        CollateralDebtData memory collateralDebtData;
+        collateralDebtData.debt = 101;
+        collateralDebtData.totalDebtUSD = 101;
+        collateralDebtData.twvUSD = 100;
+        collateralDebtData.enabledTokensMask = UNDERLYING_TOKEN_MASK | linkMask;
+        creditManagerMock.setDebtAndCollateralData(collateralDebtData);
+
+        vm.expectRevert(abi.encodeWithSelector(RemainingTokenBalanceIncreasedException.selector, (link)));
+
+        vm.prank(LIQUIDATOR);
+        creditFacade.liquidateCreditAccount({
+            creditAccount: creditAccount,
+            to: FRIEND,
+            calls: MultiCallBuilder.build(
+                MultiCall(
+                    address(adapter),
+                    abi.encodeCall(AdapterCallMock.makeCall, (link, abi.encodeCall(ERC20Mock.mint, (creditAccount, 10))))
+                )
+            )
+        });
+    }
+
+    /// @dev U:[FA-15]: `_calcPartialLiquidationPayments` works as expected
+    function test_U_FA_15_calcPartialLiquidationPayments_works_as_expected() public notExpirableCase {
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+        priceOracleMock.setPrice(dai, 1e8);
+        priceOracleMock.setPrice(link, 10e8);
+
+        (
+            ,
+            uint256 liquidationFee,
+            uint256 liquidationDiscount,
+            uint256 expiredLiquidationFee,
+            uint256 expiredLiquidationDiscount
+        ) = creditManagerMock.fees();
+        assertEq(liquidationDiscount, 96_00, "[setup]: Incorrect liquidation discount");
+        assertEq(liquidationFee, 1_50, "[setup]: Incorrect liquidation fee");
+        assertEq(expiredLiquidationDiscount, 98_00, "[setup]: Incorrect expired liquidation discount");
+        assertEq(expiredLiquidationFee, 1_00, "[setup]: Incorrect expired liquidation fee");
+
+        (uint256 repaidAmount, uint256 feeAmount, uint256 seizedAmount) = creditFacade.calcPartialLiquidationPayments({
+            amount: 1000e18,
+            token: link,
+            priceOracle: address(priceOracleMock),
+            isExpired: false
+        });
+
+        assertEq(repaidAmount, 985e18, "Incorrect repaidAmount (non-expired case)");
+        assertEq(feeAmount, 15e18, "Incorrect feeAmount (non-expired case)");
+        assertEq(
+            seizedAmount,
+            104166666666666666666, // 1000e18 / 10 * 100_00 / 96_00
+            "Incorrect seizedAmount (non-expired case)"
+        );
+
+        (repaidAmount, feeAmount, seizedAmount) = creditFacade.calcPartialLiquidationPayments({
+            amount: 1000e18,
+            token: link,
+            priceOracle: address(priceOracleMock),
+            isExpired: true
+        });
+
+        assertEq(repaidAmount, 990e18, "Incorrect repaidAmount (expired case)");
+        assertEq(feeAmount, 10e18, "Incorrect feeAmount (expired case)");
+        assertEq(
+            seizedAmount,
+            102040816326530612244, // 1000e18 / 10 * 100_00 / 98_00
+            "Incorrect seizedAmount (expired case)"
+        );
+    }
+
+    /// @dev U:[FA-16]: `partiallyLiquidateCreditAccount` works as expected
+    function test_U_FA_16_partiallyLiquidateCreditAccount_works_as_expected() public notExpirableCase {
+        address creditAccount = DUMB_ADDRESS;
+        creditManagerMock.setBorrower(USER);
+
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+
+        creditManagerMock.addToken(link, 2);
+
+        creditManagerMock.activateTransfers();
+        tokenTestSuite.mint(dai, LIQUIDATOR, 2000);
+        tokenTestSuite.mint(link, creditAccount, 200);
+        tokenTestSuite.approve(dai, LIQUIDATOR, address(creditManagerMock), type(uint256).max);
+        tokenTestSuite.approve(dai, creditAccount, address(creditManagerMock), type(uint256).max);
+        tokenTestSuite.approve(link, creditAccount, address(creditManagerMock), type(uint256).max);
+
+        priceOracleMock.setPrice(dai, 1e8);
+        priceOracleMock.setPrice(link, 10e8);
+        creditManagerMock.setPriceOracle(address(priceOracleMock));
+
+        CollateralDebtData memory collateralDebtData;
+        collateralDebtData.debt = 101;
+        collateralDebtData.totalDebtUSD = 101;
+        collateralDebtData.twvUSD = 100;
+        collateralDebtData.enabledTokensMask = 1 | 2;
+        creditManagerMock.setDebtAndCollateralData(collateralDebtData);
+
+        vm.expectRevert(UnderlyingIsNotLiquidatableException.selector);
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: dai,
+            repaidAmount: 0,
+            minSeizedAmount: 0,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(SeizedLessThanRequiredException.selector, 104));
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: link,
+            repaidAmount: 1000,
+            minSeizedAmount: 110,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(ICreditManagerV3.manageDebt, (creditAccount, 985, 1 | 2, ManageDebtAction.DECREASE_DEBT))
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(
+                ICreditManagerV3.fullCollateralCheck, (creditAccount, 1 | 2, new uint256[](0), PERCENTAGE_FACTOR, false)
+            )
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit AddCollateral(creditAccount, dai, 1000);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawCollateral(creditAccount, dai, 15, treasury);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawCollateral(creditAccount, link, 104, FRIEND);
+
+        vm.expectEmit(true, true, true, true);
+        emit PartiallyLiquidateCreditAccount(creditAccount, link, LIQUIDATOR, 985, 104, 15);
+
+        vm.prank(LIQUIDATOR);
+        uint256 seizedAmount = creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: link,
+            repaidAmount: 1000,
+            minSeizedAmount: 100,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        assertEq(seizedAmount, 104, "Incorrect seizedAmount");
+    }
+
+    /// @dev U:[FA-16A]: `partiallyLiquidateCreditAccount` works as expected when liquidated token is phantom
+    function testU_FA_16A_partiallyLiqudiateCreditAccount_works_as_expected_with_phantom_token()
+        public
+        notExpirableCase
+    {
+        address creditAccount = DUMB_ADDRESS;
+        creditManagerMock.setBorrower(USER);
+
+        address dai = tokenTestSuite.addressOf(Tokens.DAI);
+        address link = tokenTestSuite.addressOf(Tokens.LINK);
+        creditManagerMock.addToken(link, 2);
+
+        GeneralMock pDaiTarget = new GeneralMock();
+        PhantomTokenMock pDai = new PhantomTokenMock(address(pDaiTarget), dai, "Phantom DAI", "pDAI");
+        PhantomTokenWithdrawerMock pDaiWithdrawer =
+            new PhantomTokenWithdrawerMock(address(creditManagerMock), address(pDai));
+        creditManagerMock.addToken(address(pDai), 4);
+        creditManagerMock.setContractAllowance(address(pDaiWithdrawer), address(pDaiTarget));
+
+        GeneralMock pLinkTarget = new GeneralMock();
+        PhantomTokenMock pLink = new PhantomTokenMock(address(pLinkTarget), link, "Phantom LINK", "pLINK");
+        pLink.setExchangeRate(0.5e18);
+        PhantomTokenWithdrawerMock pLinkWithdrawer =
+            new PhantomTokenWithdrawerMock(address(creditManagerMock), address(pLink));
+        creditManagerMock.addToken(address(pLink), 8);
+        creditManagerMock.setContractAllowance(address(pLinkWithdrawer), address(pLinkTarget));
+
+        creditManagerMock.activateTransfers();
+        tokenTestSuite.mint(dai, LIQUIDATOR, 2000);
+        ERC20Mock(dai).set_minter(address(pDaiWithdrawer));
+        ERC20Mock(link).set_minter(address(pLinkWithdrawer));
+        pLink.mint(creditAccount, 200);
+        tokenTestSuite.approve(dai, LIQUIDATOR, address(creditManagerMock), type(uint256).max);
+        tokenTestSuite.approve(dai, creditAccount, address(creditManagerMock), type(uint256).max);
+        tokenTestSuite.approve(link, creditAccount, address(creditManagerMock), type(uint256).max);
+
+        priceOracleMock.setPrice(dai, 1e8);
+        priceOracleMock.setPrice(link, 10e8);
+        priceOracleMock.setPrice(address(pDai), 1e8);
+        priceOracleMock.setPrice(address(pLink), 10e8);
+        creditManagerMock.setPriceOracle(address(priceOracleMock));
+
+        CollateralDebtData memory collateralDebtData;
+        collateralDebtData.debt = 101;
+        collateralDebtData.totalDebtUSD = 101;
+        collateralDebtData.twvUSD = 100;
+        collateralDebtData.enabledTokensMask = 1 | 2 | 4 | 8;
+        creditManagerMock.setDebtAndCollateralData(collateralDebtData);
+
+        vm.expectRevert(UnderlyingIsNotLiquidatableException.selector);
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: address(pDai),
+            repaidAmount: 0,
+            minSeizedAmount: 0,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(SeizedLessThanRequiredException.selector, 52));
+        vm.prank(LIQUIDATOR);
+        creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: address(pLink),
+            repaidAmount: 1000,
+            minSeizedAmount: 55,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        vm.expectCall(
+            address(creditManagerMock), abi.encodeCall(ICreditManagerV3.setActiveCreditAccount, (creditAccount))
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(
+                ICreditManagerV3.manageDebt, (creditAccount, 985, 1 | 2 | 4 | 8, ManageDebtAction.DECREASE_DEBT)
+            )
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(ICreditManagerV3.setActiveCreditAccount, (INACTIVE_CREDIT_ACCOUNT_ADDRESS))
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(
+                ICreditManagerV3.fullCollateralCheck,
+                (creditAccount, 1 | 2 | 4 | 8, new uint256[](0), PERCENTAGE_FACTOR, false)
+            )
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit AddCollateral(creditAccount, dai, 1000);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawPhantomToken(creditAccount, address(pLink), 104);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawCollateral(creditAccount, dai, 15, treasury);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawCollateral(creditAccount, link, 52, FRIEND);
+
+        vm.expectEmit(true, true, true, true);
+        emit PartiallyLiquidateCreditAccount(creditAccount, link, LIQUIDATOR, 985, 52, 15);
+
+        vm.prank(LIQUIDATOR);
+        uint256 seizedAmount = creditFacade.partiallyLiquidateCreditAccount({
+            creditAccount: creditAccount,
+            token: address(pLink),
+            repaidAmount: 1000,
+            minSeizedAmount: 50,
+            to: FRIEND,
+            priceUpdates: new PriceUpdate[](0)
+        });
+
+        assertEq(seizedAmount, 52, "Incorrect seizedAmount");
     }
 
     /// @dev U:[FA-17]: liquidateCreditAccount correctly handles loss
@@ -1526,6 +1801,97 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         });
     }
 
+    /// @dev U:[FA-36A]: multicall `withdrawCollateral` with phantom tokens works properly
+    function test_U_FA_36A_multicall_withdrawCollateral_with_phantom_token_works_correctly() public notExpirableCase {
+        address creditAccount = DUMB_ADDRESS;
+        uint256 amount = 100;
+
+        GeneralMock targetContract = new GeneralMock();
+        ERC20Mock depositedToken = new ERC20Mock("Test Token", "TEST", 18);
+
+        PhantomTokenMock phantomToken =
+            new PhantomTokenMock(address(targetContract), address(depositedToken), "Phantom Token", "PHANTOM");
+        PhantomTokenWithdrawerMock adapter =
+            new PhantomTokenWithdrawerMock(address(creditManagerMock), address(phantomToken));
+
+        depositedToken.set_minter(address(adapter));
+        phantomToken.mint(creditAccount, amount);
+        phantomToken.setExchangeRate(0.5e18);
+
+        MultiCall[] memory calls = MultiCallBuilder.build(
+            MultiCall({
+                target: address(creditFacade),
+                callData: abi.encodeCall(ICreditFacadeV3Multicall.withdrawCollateral, (address(phantomToken), amount, USER))
+            })
+        );
+
+        vm.expectRevert(TokenNotAllowedException.selector);
+        creditFacade.multicallInt({
+            creditAccount: creditAccount,
+            calls: calls,
+            enabledTokensMask: 0,
+            flags: WITHDRAW_COLLATERAL_PERMISSION
+        });
+
+        creditManagerMock.addToken(address(depositedToken), 1 << 1);
+        creditManagerMock.addToken(address(phantomToken), 1 << 2);
+
+        vm.expectRevert(TargetContractNotAllowedException.selector);
+        creditFacade.multicallInt({
+            creditAccount: creditAccount,
+            calls: calls,
+            enabledTokensMask: 0,
+            flags: WITHDRAW_COLLATERAL_PERMISSION
+        });
+
+        creditManagerMock.setContractAllowance({adapter: address(adapter), targetContract: address(targetContract)});
+
+        vm.expectCall(
+            address(creditManagerMock), abi.encodeCall(ICreditManagerV3.setActiveCreditAccount, (creditAccount))
+        );
+
+        vm.expectCall(
+            address(adapter),
+            abi.encodeCall(PhantomTokenWithdrawerMock.withdrawPhantomToken, (address(phantomToken), amount))
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(
+                ICreditManagerV3.withdrawCollateral, (creditAccount, address(depositedToken), amount / 2, USER)
+            )
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(ICreditManagerV3.setActiveCreditAccount, (INACTIVE_CREDIT_ACCOUNT_ADDRESS))
+        );
+
+        vm.expectCall(
+            address(creditManagerMock),
+            abi.encodeCall(
+                ICreditManagerV3.fullCollateralCheck,
+                (creditAccount, UNDERLYING_TOKEN_MASK, new uint256[](0), PERCENTAGE_FACTOR, true)
+            )
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit Execute(creditAccount, address(targetContract));
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawPhantomToken(creditAccount, address(phantomToken), amount);
+
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawCollateral(creditAccount, address(depositedToken), amount / 2, USER);
+
+        creditFacade.multicallInt({
+            creditAccount: creditAccount,
+            calls: calls,
+            enabledTokensMask: 0,
+            flags: WITHDRAW_COLLATERAL_PERMISSION
+        });
+    }
+
     /// @dev U:[FA-37]: multicall `setBotPermissions` works properly
     function test_U_FA_37_setBotPermissions_works_properly() public notExpirableCase {
         address creditAccount = DUMB_ADDRESS;
@@ -1796,7 +2162,7 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
     function test_U_FA_46_isExpired_works_properly(uint40 timestamp) public allExpirableCases {
         vm.assume(timestamp > 1);
 
-        assertTrue(!creditFacade.isExpired(), "isExpired unexpectedly returns true (expiration date not set)");
+        assertTrue(!creditFacade.isExpiredInt(), "isExpired unexpectedly returns true (expiration date not set)");
 
         if (expirable) {
             vm.prank(CONFIGURATOR);
@@ -1804,10 +2170,10 @@ contract CreditFacadeV3UnitTest is TestHelper, BalanceHelper, ICreditFacadeV3Eve
         }
 
         vm.warp(timestamp - 1);
-        assertTrue(!creditFacade.isExpired(), "isExpired unexpectedly returns true (not expired)");
+        assertTrue(!creditFacade.isExpiredInt(), "isExpired unexpectedly returns true (not expired)");
 
         vm.warp(timestamp);
-        assertEq(creditFacade.isExpired(), expirable, "Incorrect isExpired");
+        assertEq(creditFacade.isExpiredInt(), expirable, "Incorrect isExpired");
     }
 
     /// @dev U:[FA-48]: rsetExpirationDate works properly

--- a/contracts/test/unit/credit/CreditFacadeV3Harness.sol
+++ b/contracts/test/unit/credit/CreditFacadeV3Harness.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 
 import "../../../interfaces/ICreditFacadeV3.sol";
 import {CreditFacadeV3} from "../../../credit/CreditFacadeV3.sol";
-import {ManageDebtAction} from "../../../interfaces/ICreditManagerV3.sol";
+import {ManageDebtAction, CollateralDebtData} from "../../../interfaces/ICreditManagerV3.sol";
 import {BalanceWithMask} from "../../../libraries/BalancesLogic.sol";
 
 contract CreditFacadeV3Harness is CreditFacadeV3 {
@@ -31,6 +31,18 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
         _revertIfOutOfDebtPerBlockLimit(amount);
     }
 
+    function revertIfNotLiquidatable(address creditAccount) external view returns (CollateralDebtData memory, bool) {
+        return _revertIfNotLiquidatable(creditAccount);
+    }
+
+    function calcPartialLiquidationPayments(uint256 amount, address token, address priceOracle, bool isExpired)
+        external
+        view
+        returns (uint256, uint256, uint256)
+    {
+        return _calcPartialLiquidationPayments(amount, token, priceOracle, isExpired);
+    }
+
     function setLastBlockBorrowed(uint64 _lastBlockBorrowed) external {
         lastBlockBorrowed = _lastBlockBorrowed;
     }
@@ -51,7 +63,7 @@ contract CreditFacadeV3Harness is CreditFacadeV3 {
         _revertIfOutOfDebtLimits(debt, action);
     }
 
-    function isExpired() external view returns (bool) {
+    function isExpiredInt() external view returns (bool) {
         return _isExpired();
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ libs = ['lib']
 out = 'out'
 solc_version = '0.8.17'
 evm_version = 'london'
-optimizer_runs = 12000
+optimizer_runs = 1000
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config
 block_number = 120000 


### PR DESCRIPTION
Notion of phantom tokens is added to the core.
When adding a phantom token as collateral, credit configurator checks that its deposited token is already added as collateral.
When withdrawing a phantom token in the credit facade, a call to a withdrawer adapter is made first to unwrap phantom token into its deposited token.

Number of optimizer runs is decreased to `1000` (which was actually always used in practice) for all contracts to fit into a size limit.