### PR TITLE
feat: extend contract types

### DIFF
--- a/contracts/core/AccountFactoryV3.sol
+++ b/contracts/core/AccountFactoryV3.sol
@@ -45,7 +45,7 @@ contract AccountFactoryV3 is IAccountFactoryV3, Ownable {
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "AF";
+    bytes32 public constant override contractType = "ACCOUNT_FACTORY";
 
     /// @notice Delay after which returned credit accounts can be reused
     uint40 public constant override delay = 3 days;

--- a/contracts/core/BotListV3.sol
+++ b/contracts/core/BotListV3.sol
@@ -28,7 +28,7 @@ contract BotListV3 is IBotListV3, SanityCheckTrait, Ownable {
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "BL";
+    bytes32 public constant override contractType = "BOT_LIST";
 
     /// @notice Credit manager's approved status
     mapping(address => bool) public override approvedCreditManager;

--- a/contracts/core/GearStakingV3.sol
+++ b/contracts/core/GearStakingV3.sol
@@ -33,7 +33,7 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "GS";
+    bytes32 public constant override contractType = "GEAR_STAKING";
 
     /// @notice Address of the GEAR token
     address public immutable override gear;

--- a/contracts/core/PriceOracleV3.sol
+++ b/contracts/core/PriceOracleV3.sol
@@ -41,7 +41,7 @@ contract PriceOracleV3 is ControlledTrait, PriceFeedValidationTrait, SanityCheck
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "PO";
+    bytes32 public constant override contractType = "PRICE_ORACLE";
 
     /// @dev Mapping from token address to price feed params
     mapping(address => PriceFeedParams) internal _priceFeedsParams;

--- a/contracts/credit/CreditAccountV3.sol
+++ b/contracts/credit/CreditAccountV3.sol
@@ -20,7 +20,7 @@ contract CreditAccountV3 is ICreditAccountV3 {
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "CA";
+    bytes32 public constant override contractType = "CREDIT_ACCOUNT";
 
     /// @notice Account factory this account was deployed with
     address public immutable override factory;

--- a/contracts/credit/CreditConfiguratorV3.sol
+++ b/contracts/credit/CreditConfiguratorV3.sol
@@ -43,7 +43,7 @@ contract CreditConfiguratorV3 is ICreditConfiguratorV3, ControlledTrait, SanityC
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "CC";
+    bytes32 public constant override contractType = "CREDIT_CONFIGURATOR";
 
     /// @notice Credit manager address
     address public immutable override creditManager;

--- a/contracts/credit/CreditFacadeV3.sol
+++ b/contracts/credit/CreditFacadeV3.sol
@@ -72,7 +72,7 @@ contract CreditFacadeV3 is ICreditFacadeV3, Pausable, ACLTrait, ReentrancyGuardT
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "CF";
+    bytes32 public constant override contractType = "CREDIT_FACADE";
 
     /// @notice Maximum quota size, as a multiple of `maxDebt`
     uint256 public constant override maxQuotaMultiplier = 2;

--- a/contracts/credit/CreditManagerV3.sol
+++ b/contracts/credit/CreditManagerV3.sol
@@ -184,7 +184,7 @@ contract CreditManagerV3 is ICreditManagerV3, SanityCheckTrait, ReentrancyGuardT
 
     /// @notice Contract type
     function contractType() external view virtual override returns (bytes32) {
-        return "CM";
+        return "CREDIT_MANAGER";
     }
 
     // ------------------ //

--- a/contracts/credit/CreditManagerV3_USDT.sol
+++ b/contracts/credit/CreditManagerV3_USDT.sol
@@ -11,7 +11,7 @@ import {IPoolV3} from "../interfaces/IPoolV3.sol";
 /// @notice Credit manager variation for USDT underlying with enabled transfer fees
 contract CreditManagerV3_USDT is CreditManagerV3, USDT_Transfer {
     /// @notice Contract type
-    bytes32 public constant override contractType = "CM_USDT";
+    bytes32 public constant override contractType = "CREDIT_MANAGER_USDT";
 
     constructor(
         address _pool,

--- a/contracts/interfaces/base/IBot.sol
+++ b/contracts/interfaces/base/IBot.sol
@@ -3,10 +3,12 @@
 // (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.17;
 
+import {IVersion} from "./IVersion.sol";
+
 /// @title Bot interface
 /// @notice Minimal interface contracts must conform to in order to be used as bots in Gearbox V3
 /// @dev Since bots might be developed by third-parties, there're no requirements on version or type
-interface IBot {
+interface IBot is IVersion {
     /// @notice Mask of permissions required for bot operation, see `ICreditFacadeV3Multicall`
     function requiredPermissions() external view returns (uint192);
 }

--- a/contracts/pool/PoolQuotaKeeperV3.sol
+++ b/contracts/pool/PoolQuotaKeeperV3.sol
@@ -38,7 +38,7 @@ contract PoolQuotaKeeperV3 is IPoolQuotaKeeperV3, ControlledTrait, ContractsRegi
     uint256 public constant override version = 3_10;
 
     /// @notice Contract type
-    bytes32 public constant override contractType = "QK";
+    bytes32 public constant override contractType = "POOL_QUOTA_KEEPER";
 
     /// @notice Address of the underlying token
     address public immutable override underlying;

--- a/contracts/pool/PoolV3.sol
+++ b/contracts/pool/PoolV3.sol
@@ -155,7 +155,7 @@ contract PoolV3 is
 
     /// @notice Contract type
     function contractType() external view virtual override returns (bytes32) {
-        return "LP";
+        return "POOL";
     }
 
     /// @notice Pool shares decimals, matches underlying token decimals

--- a/contracts/pool/PoolV3_USDT.sol
+++ b/contracts/pool/PoolV3_USDT.sol
@@ -10,7 +10,7 @@ import {USDT_Transfer} from "../traits/USDT_Transfer.sol";
 /// @notice Pool variation for USDT underlying with enabled transfer fees
 contract PoolV3_USDT is PoolV3, USDT_Transfer {
     /// @notice Contract type
-    bytes32 public constant override contractType = "LP_USDT";
+    bytes32 public constant override contractType = "POOL_USDT";
 
     constructor(
         address acl_,

--- a/contracts/test/mocks/core/AccountFactoryMock.sol
+++ b/contracts/test/mocks/core/AccountFactoryMock.sol
@@ -16,7 +16,7 @@ contract AccountFactoryMock is Test, IAccountFactoryV3 {
     /// @dev Contract version
     uint256 public version;
 
-    bytes32 public constant override contractType = "AF_MOCK";
+    bytes32 public constant override contractType = "ACCOUNT_FACTORY_MOCK";
 
     address public usedAccount;
 

--- a/contracts/test/mocks/core/AdapterMock.sol
+++ b/contracts/test/mocks/core/AdapterMock.sol
@@ -9,7 +9,7 @@ import {IAdapter} from "../../../interfaces/base/IAdapter.sol";
 /// @title Adapter Mock
 contract AdapterMock is IAdapter {
     uint256 public constant override version = 3_10;
-    bytes32 public constant override contractType = "AD_MOCK";
+    bytes32 public constant override contractType = "ADAPTER_MOCK";
 
     address public immutable override creditManager;
     address public immutable override targetContract;

--- a/contracts/test/mocks/core/BotMock.sol
+++ b/contracts/test/mocks/core/BotMock.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.8.17;
 import {IBot} from "../../../interfaces/base/IBot.sol";
 
 contract BotMock is IBot {
+    uint256 public constant override version = 3_10;
+    bytes32 public constant override contractType = "BOT_MOCK";
     uint192 public override requiredPermissions;
 
     function setRequiredPermissions(uint192 permissions) external {

--- a/contracts/test/mocks/credit/CreditAccountMock.sol
+++ b/contracts/test/mocks/credit/CreditAccountMock.sol
@@ -22,7 +22,7 @@ contract CreditAccountMock is ICreditAccountV3, CreditAccountMockEvents {
     // Contract version
     uint256 public constant version = 3_10;
 
-    bytes32 public constant contractType = "CA_MOCK";
+    bytes32 public constant contractType = "CREDIT_ACCOUNT_MOCK";
 
     bytes public return_executeResult;
 

--- a/contracts/test/mocks/governance/GearStakingMock.sol
+++ b/contracts/test/mocks/governance/GearStakingMock.sol
@@ -9,7 +9,7 @@ import {EPOCHS_TO_WITHDRAW} from "../../../libraries/Constants.sol";
 contract GearStakingMock is IGearStakingV3 {
     uint256 public constant version = 3_10;
 
-    bytes32 public constant override contractType = "GS_MOCK";
+    bytes32 public constant override contractType = "GEAR_STAKING_MOCK";
 
     uint16 public getCurrentEpoch;
 

--- a/contracts/test/mocks/oracles/PriceFeedMock.sol
+++ b/contracts/test/mocks/oracles/PriceFeedMock.sol
@@ -15,7 +15,7 @@ enum FlagState {
 /// @notice Used for test purposes only
 contract PriceFeedMock is IPriceFeed {
     uint256 public constant override version = 3_10;
-    bytes32 public constant override contractType = "PF_MOCK";
+    bytes32 public constant override contractType = "PRICE_FEED_MOCK";
 
     int256 private price;
     uint8 public immutable override decimals;

--- a/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
+++ b/contracts/test/mocks/pool/PoolQuotaKeeperMock.sol
@@ -8,7 +8,7 @@ import {TokenQuotaParams, AccountQuota} from "../../../interfaces/IPoolQuotaKeep
 contract PoolQuotaKeeperMock {
     uint256 public constant version = 3_10;
 
-    bytes32 public constant contractType = "QK_MOCK";
+    bytes32 public constant contractType = "POOL_QUOTA_KEEPER_MOCK";
 
     /// @dev Address provider
     address public immutable underlying;

--- a/contracts/test/mocks/token/PhantomTokenMock.sol
+++ b/contracts/test/mocks/token/PhantomTokenMock.sol
@@ -12,7 +12,7 @@ import {ERC20Mock} from "../token/ERC20Mock.sol";
 
 contract PhantomTokenMock is IPhantomToken, ERC20 {
     uint256 public constant override version = 3_10;
-    bytes32 public constant override contractType = "PT_MOCK";
+    bytes32 public constant override contractType = "PHANTOM_TOKEN_MOCK";
 
     address public immutable target;
     address public immutable depositedToken;
@@ -53,7 +53,7 @@ contract PhantomTokenMock is IPhantomToken, ERC20 {
 
 contract PhantomTokenWithdrawerMock is IAdapter, IPhantomTokenWithdrawer {
     uint256 public constant override version = 3_10;
-    bytes32 public constant override contractType = "AD_PHANTOM_TOKEN_WITHDRAWER_MOCK";
+    bytes32 public constant override contractType = "PHANTOM_TOKEN_WITHDRAWER_MOCK";
 
     address public immutable override creditManager;
     address public immutable override targetContract;


### PR DESCRIPTION
Having `contractType` return the full contract name makes more sense and doesn't cost anything since it shouldn't really be queried on-chain.

The general rule for naming is to use snake-cased capitalized name of the contract without the `V3` prefix.
The exceptions are contracts that implement interfaces `IAdapter`, `IPriceFeed`, `IBot`, `IRateKeeper`, `IInterestRateModel` (also `IZapper`, which is not included in this repo), which start with respective abbreviation.