### PR TITLE
feat: simplify `TumblerV3`'s deployment

### DIFF
--- a/contracts/pool/TumblerV3.sol
+++ b/contracts/pool/TumblerV3.sol
@@ -50,13 +50,15 @@ contract TumblerV3 is ITumblerV3, ControlledTrait, SanityCheckTrait {
     mapping(address => uint16) internal _rates;
 
     /// @notice Constructor
-    /// @param pool_ Pool whose quota rates to set by this contract
+    /// @param poolQuotaKeeper_ Quota keeper of the pool whose rates to set by this contract
     /// @param epochLength_ Epoch length in seconds
     /// @custom:tests U:[TU-1]
-    constructor(address pool_, uint256 epochLength_) ControlledTrait(ControlledTrait(pool_).acl()) {
-        pool = pool_;
-        underlying = IPoolV3(pool_).underlyingToken();
-        poolQuotaKeeper = IPoolV3(pool_).poolQuotaKeeper();
+    constructor(address poolQuotaKeeper_, uint256 epochLength_)
+        ControlledTrait(ControlledTrait(IPoolQuotaKeeperV3(poolQuotaKeeper_).pool()).acl())
+    {
+        pool = IPoolQuotaKeeperV3(poolQuotaKeeper_).pool();
+        underlying = IPoolQuotaKeeperV3(poolQuotaKeeper_).underlying();
+        poolQuotaKeeper = poolQuotaKeeper_;
         epochLength = epochLength_;
     }
 

--- a/contracts/test/integration/governance/QuotaRates.int.t.sol
+++ b/contracts/test/integration/governance/QuotaRates.int.t.sol
@@ -34,7 +34,7 @@ contract QuotaRatesIntegrationTest is Test {
         quotaKeeper = new PoolQuotaKeeperV3(address(pool));
         pool.setPoolQuotaKeeper(address(quotaKeeper));
 
-        tumbler = new TumblerV3(address(pool), 1 days);
+        tumbler = new TumblerV3(address(quotaKeeper), 1 days);
         quotaKeeper.setGauge(address(tumbler));
     }
 

--- a/contracts/test/unit/pool/TumblerV3.unit.t.sol
+++ b/contracts/test/unit/pool/TumblerV3.unit.t.sol
@@ -40,7 +40,7 @@ contract TumblerV3UnitTest is Test, ITumblerV3Events {
         poolQuotaKeeper.set_lastQuotaRateUpdate(uint40(block.timestamp));
         pool.setPoolQuotaKeeper(address(poolQuotaKeeper));
 
-        tumbler = new TumblerV3(address(pool), 1 days);
+        tumbler = new TumblerV3(address(poolQuotaKeeper), 1 days);
     }
 
     /// @notice U:[TU-1]: Constructor works as expected


### PR DESCRIPTION
Previously, `TumblerV3`'s constructor was accepting `pool` as argument and reading `poolQuotaKeeper` from there. This caused complications in deployments since it required a configurator-only function `setPoolQuotaKeeper` to be called between contract creations. This PR changes the constructor to accept `poolQuotaKeeper` instead of the pool, which allows to deploy contracts first and configure them later.
Note that this is the only occurrence of such issue in core contracts.