### PR TITLE
fix: postponed GEAR initialization

### DIFF
--- a/contracts/core/GearStakingV3.sol
+++ b/contracts/core/GearStakingV3.sol
@@ -43,11 +43,11 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     /// @notice Contract type
     bytes32 public constant override contractType = "GEAR_STAKING";
 
-    ///
-    address public immutable addressProvider;
+    /// @dev Address provider contract address
+    address internal immutable _addressProvider;
 
-    /// @notice Address of the GEAR token
-    address public gear;
+    /// @dev Cached GEAR token address
+    address internal _gearCached;
 
     /// @notice Timestamp of the first epoch of voting
     uint256 public constant override firstEpochTimestamp = FIRST_EPOCH_TIMESTAMP;
@@ -76,15 +76,28 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     /// @notice Constructor
     /// @param addressProvider_ Address provider contract address
     constructor(address addressProvider_) {
-        addressProvider = addressProvider_;
-        try IAddressProvider(addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL) returns (
+        _addressProvider = addressProvider_;
+        try IAddressProvider(_addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL) returns (
             address gear_
         ) {
-            gear = gear_;
+            _gearCached = gear_;
         } catch {}
         transferOwnership(
             IAddressProvider(addressProvider_).getAddressOrRevert(AP_CROSS_CHAIN_GOVERNANCE_PROXY, NO_VERSION_CONTROL)
         ); // U:[GS-1]
+    }
+
+    /// @notice Returns the address of the GEAR token
+    function gear() external view override returns (address) {
+        if (_gearCached != address(0)) return _gearCached;
+        return IAddressProvider(_addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL);
+    }
+
+    /// @dev Caches the address of the GEAR token and returns it
+    function _gear() internal returns (address) {
+        if (_gearCached != address(0)) return _gearCached;
+        _gearCached = IAddressProvider(_addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL);
+        return _gearCached;
     }
 
     /// @notice Stakes given amount of GEAR, and, optionally, performs a sequence of votes
@@ -355,18 +368,5 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
 
             emit SetMigrator(newMigrator); // U:[GS-9]
         }
-    }
-
-    function _gear() public returns (address) {
-        if (gear == address(0)) {
-            try IAddressProvider(addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL) returns (
-                address gear_
-            ) {
-                gear = gear_;
-            } catch {
-                revert GearIsNotSetException();
-            }
-        }
-        return gear;
     }
 }

--- a/contracts/core/GearStakingV3.sol
+++ b/contracts/core/GearStakingV3.sol
@@ -43,8 +43,11 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     /// @notice Contract type
     bytes32 public constant override contractType = "GEAR_STAKING";
 
+    ///
+    address public immutable addressProvider;
+
     /// @notice Address of the GEAR token
-    address public immutable override gear;
+    address public gear;
 
     /// @notice Timestamp of the first epoch of voting
     uint256 public constant override firstEpochTimestamp = FIRST_EPOCH_TIMESTAMP;
@@ -73,7 +76,12 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
     /// @notice Constructor
     /// @param addressProvider_ Address provider contract address
     constructor(address addressProvider_) {
-        gear = IAddressProvider(addressProvider_).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL); // U:[GS-1]
+        addressProvider = addressProvider_;
+        try IAddressProvider(addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL) returns (
+            address gear_
+        ) {
+            gear = gear_;
+        } catch {}
         transferOwnership(
             IAddressProvider(addressProvider_).getAddressOrRevert(AP_CROSS_CHAIN_GOVERNANCE_PROXY, NO_VERSION_CONTROL)
         ); // U:[GS-1]
@@ -100,13 +108,13 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
         bytes32 r,
         bytes32 s
     ) external override nonReentrant {
-        try IERC20Permit(gear).permit(msg.sender, address(this), amount, deadline, v, r, s) {} catch {} // U:[GS-2]
+        try IERC20Permit(_gear()).permit(msg.sender, address(this), amount, deadline, v, r, s) {} catch {} // U:[GS-2]
         _deposit(amount, msg.sender, votes); // U:[GS-2]
     }
 
     /// @dev Implementation of `deposit`
     function _deposit(uint96 amount, address to, MultiVote[] calldata votes) internal {
-        IERC20(gear).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(_gear()).safeTransferFrom(msg.sender, address(this), amount);
 
         UserVoteLockData storage vld = voteLockData[to];
 
@@ -173,7 +181,7 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
             vld.totalStaked -= amount; // U:[GS-7]
         }
 
-        IERC20(gear).approve(successor, uint256(amount));
+        IERC20(_gear()).approve(successor, uint256(amount));
         IGearStakingV3(successor).depositOnMigration(amount, msg.sender, votesAfter); // U:[GS-7]
 
         emit MigrateGear(msg.sender, successor, amount); // U:[GS-7]
@@ -218,7 +226,7 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
             }
 
             if (totalClaimable != 0) {
-                IERC20(gear).safeTransfer(to, totalClaimable);
+                IERC20(_gear()).safeTransfer(to, totalClaimable);
 
                 voteLockData[user].totalStaked -= totalClaimable.toUint96();
 
@@ -347,5 +355,18 @@ contract GearStakingV3 is IGearStakingV3, Ownable, ReentrancyGuardTrait, SanityC
 
             emit SetMigrator(newMigrator); // U:[GS-9]
         }
+    }
+
+    function _gear() public returns (address) {
+        if (gear == address(0)) {
+            try IAddressProvider(addressProvider).getAddressOrRevert(AP_GEAR_TOKEN, NO_VERSION_CONTROL) returns (
+                address gear_
+            ) {
+                gear = gear_;
+            } catch {
+                revert GearIsNotSetException();
+            }
+        }
+        return gear;
     }
 }

--- a/contracts/interfaces/IGearStakingV3.sol
+++ b/contracts/interfaces/IGearStakingV3.sol
@@ -63,8 +63,6 @@ interface IGearStakingV3Events {
 
 /// @title Gear staking V3 interface
 interface IGearStakingV3 is IGearStakingV3Events, IVersion {
-    error GearIsNotSetException();
-
     function gear() external view returns (address);
 
     function firstEpochTimestamp() external view returns (uint256);

--- a/contracts/interfaces/IGearStakingV3.sol
+++ b/contracts/interfaces/IGearStakingV3.sol
@@ -63,6 +63,8 @@ interface IGearStakingV3Events {
 
 /// @title Gear staking V3 interface
 interface IGearStakingV3 is IGearStakingV3Events, IVersion {
+    error GearIsNotSetException();
+
     function gear() external view returns (address);
 
     function firstEpochTimestamp() external view returns (uint256);


### PR DESCRIPTION
During the deployment to L2, I found a situation where the GEARStaking contract is deployed, but GEARR token is only assigned when the `activate` function is called. Because of that, GearStaking reverts in the constructor and the deployment gets stuck. To solve this, I implemented a function that performs a delayed assignment — it sets Gear address at the moment of first use by a staker, rather than immediately. 